### PR TITLE
Use correct instalation path for RPMs

### DIFF
--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -58,7 +58,7 @@
         "postRemoveScript": "scripts/rpm/postrm",
         "files": {
           "/usr/share/com.ticklab.biopass/download_models.sh": "scripts/download_models.sh",
-          "/lib/security/libbiopass_pam.so": "../../auth/build/pam/libbiopass_pam.so",
+          "/lib64/security/libbiopass_pam.so": "../../auth/build/pam/libbiopass_pam.so",
           "/usr/local/bin/biopass-helper": "../../auth/build/pam/biopass-helper",
           "/usr/lib/biopass/libbiopass_det.so": "../../auth/build/face/detection/libbiopass_det.so",
           "/usr/lib/biopass/libbiopass_reg.so": "../../auth/build/face/recognition/libbiopass_reg.so",


### PR DESCRIPTION
Fedora doesn't use /lib/security for the pam modules by default but /lib64/security.