### PR TITLE
feat: Add PAM config file to simplify enabling the module

### DIFF
--- a/app/src-tauri/assets/pam-configs/biopass
+++ b/app/src-tauri/assets/pam-configs/biopass
@@ -1,0 +1,6 @@
+Name: Biopass - face and fingerprint authentication
+Default: no
+Priority: 260
+Auth-Type: Primary
+Auth:
+        [success=2 default=ignore]      libbiopass_pam.so

--- a/app/src-tauri/assets/pam-configs/biopass
+++ b/app/src-tauri/assets/pam-configs/biopass
@@ -3,4 +3,4 @@ Default: no
 Priority: 260
 Auth-Type: Primary
 Auth:
-        [success=2 default=ignore]      libbiopass_pam.so
+	[success=2 default=ignore]	libbiopass_pam.so

--- a/app/src-tauri/assets/pam-configs/biopass
+++ b/app/src-tauri/assets/pam-configs/biopass
@@ -3,4 +3,4 @@ Default: no
 Priority: 260
 Auth-Type: Primary
 Auth:
-	[success=2 default=ignore]	libbiopass_pam.so
+	[success=sufficient default=ignore]	libbiopass_pam.so

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -47,7 +47,8 @@
           "/usr/lib/biopass/libbiopass_as.so": "../../auth/build/face/antispoofing/libbiopass_as.so",
           "/usr/lib/biopass/libonnxruntime.so.1": "../../auth/build/_deps/onnxruntime-src/lib/libonnxruntime.so.1.19.2",
           "/usr/lib/biopass/libopenpnp-capture.so.0": "../../auth/build/_deps/openpnp-capture-build/libopenpnp-capture.so.0.0.28",
-          "/etc/ld.so.conf.d/biopass.conf": "scripts/biopass-ldconf"
+          "/etc/ld.so.conf.d/biopass.conf": "scripts/biopass-ldconf",
+          "/usr/share/pam-configs/biopass": "assets/pam-configs/biopass"
         }
       },
       "rpm": {
@@ -63,7 +64,8 @@
           "/usr/lib/biopass/libbiopass_as.so": "../../auth/build/face/antispoofing/libbiopass_as.so",
           "/usr/lib/biopass/libonnxruntime.so.1": "../../auth/build/_deps/onnxruntime-src/lib/libonnxruntime.so.1.19.2",
           "/usr/lib/biopass/libopenpnp-capture.so.0": "../../auth/build/_deps/openpnp-capture-build/libopenpnp-capture.so.0.0.28",
-          "/etc/ld.so.conf.d/biopass.conf": "scripts/biopass-ldconf"
+          "/etc/ld.so.conf.d/biopass.conf": "scripts/biopass-ldconf",
+          "/usr/share/pam-configs/biopass": "assets/pam-configs/biopass"
         }
       }
     }


### PR DESCRIPTION
Introducing a PAM config file `/usr/share/pam-configs/biopass` that simplifies enabling the module by `pam-auth-update` command.

Resolves #72