### PR TITLE
fix: require all enabled anti-spoofing methods to pass

### DIFF
--- a/auth/face/antispoofing/antispoof_check.cc
+++ b/auth/face/antispoofing/antispoof_check.cc
@@ -103,7 +103,7 @@ bool checkAntiSpoof(const FaceMethodConfig& face_config, const std::string& user
         })));
   }
 
-  bool any_success = false;
+  bool all_passed = true;
   for (auto& task : tasks) {
     bool ok = false;
     try {
@@ -114,16 +114,16 @@ bool checkAntiSpoof(const FaceMethodConfig& face_config, const std::string& user
     }
     if (ok) {
       spdlog::debug("FaceAuth: {} anti-spoofing method passed", task.name);
-      any_success = true;
     } else {
       spdlog::debug("FaceAuth: {} anti-spoofing method failed", task.name);
+      all_passed = false;
     }
   }
 
-  if (!any_success) {
-    spdlog::error("FaceAuth: Anti-spoofing failed (all enabled methods failed)");
+  if (!all_passed) {
+    spdlog::error("FaceAuth: Anti-spoofing failed (one or more enabled methods failed)");
   }
-  return any_success;
+  return all_passed;
 }
 
 }  // namespace biopass

--- a/auth/pam/helper.cc
+++ b/auth/pam/helper.cc
@@ -1,4 +1,5 @@
 #include <spdlog/spdlog.h>
+#include <spdlog/sinks/ansicolor_sink.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -64,6 +65,8 @@ int authenticate(const std::string& username, const std::string& service) {
     return 2;  // PAM_IGNORE
   }
 
+  auto stderr_sink = std::make_shared<spdlog::sinks::ansicolor_stderr_sink_mt>();
+  spdlog::set_default_logger(std::make_shared<spdlog::logger>("biopass", stderr_sink));
   if (config.strategy.debug) {
     spdlog::set_level(spdlog::level::debug);
   } else {


### PR DESCRIPTION
- Fixed critical security bug in anti-spoofing result aggregation: changed OR logic (any_success) to AND logic (all_passed) in antispoof_check.cc. Previously, if any single method passed (e.g. AI       
  model), authentication succeeded even if other enabled methods failed (e.g. IR camera). Now all enabled methods must pass.
  - Fixed biopass-helper logging to stderr instead of stdout, preventing log output from polluting command substitution in calling scripts (e.g. Omarchy updater capturing FaceAuth logs as snapper config  
  argument).                                                                                                                                                                                                
   
  Reproduction (security bug)                                                                                                                                                                               
                  
  Hold a phone photo in front of camera with both AI + IR anti-spoofing enabled. IR correctly detects no IR signature → fails. AI model passes. Old behavior: auth succeeds. New behavior: auth denied.     
   
  Files changed                                                                                                                                                                                             
                  
  - auth/face/antispoofing/antispoof_check.cc — AND aggregation for multi-method anti-spoofing                                                                                                              
  - auth/pam/helper.cc — spdlog redirected to stderr sink