### PR TITLE
CachyOS/Arch Linux fixes: WebKitGTK camera, YOLOv8 detection, V4L2 NV12, anti-spoofing, heap corruption, advanced config, and UI refinements

### DIFF
--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -19,7 +19,7 @@ tauri-build = { version = "2", features = [] }
 pkg-config = "0.3"
 
 [dependencies]
-tauri = { version = "2", features = ["protocol-asset"] }
+tauri = { version = "2", features = ["protocol-asset", "custom-protocol"] }
 tauri-plugin-opener = "2"
 tauri-plugin-fs = "2"
 serde = { version = "1", features = ["derive"] }

--- a/app/src-tauri/src/camera.rs
+++ b/app/src-tauri/src/camera.rs
@@ -1,0 +1,203 @@
+use base64::{engine::general_purpose, Engine as _};
+use std::io::Read;
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+
+pub struct CameraPreview {
+    process: Option<std::process::Child>,
+    latest_frame: Arc<Mutex<Option<Vec<u8>>>>,
+    running: Arc<AtomicBool>,
+    thread_handle: Option<std::thread::JoinHandle<()>>,
+}
+
+impl CameraPreview {
+    pub fn start(device_path: &str) -> Result<Self, String> {
+        let mut child = Command::new("ffmpeg")
+            .args([
+                "-hide_banner",
+                "-loglevel",
+                "quiet",
+                "-f",
+                "v4l2",
+                "-video_size",
+                "640x480",
+                "-i",
+                device_path,
+                "-c:v",
+                "mjpeg",
+                "-q:v",
+                "5",
+                "-f",
+                "image2pipe",
+                "-",
+            ])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .map_err(|e| format!("Failed to start camera: {}. Is ffmpeg installed?", e))?;
+
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or("Failed to capture camera output")?;
+
+        let latest_frame: Arc<Mutex<Option<Vec<u8>>>> = Arc::new(Mutex::new(None));
+        let running = Arc::new(AtomicBool::new(true));
+
+        let frame_ref = latest_frame.clone();
+        let running_ref = running.clone();
+
+        let handle = thread::spawn(move || {
+            let mut reader = std::io::BufReader::new(stdout);
+            let mut buf = Vec::new();
+
+            while running_ref.load(Ordering::Relaxed) {
+                let mut chunk = vec![0u8; 65536];
+                match reader.read(&mut chunk) {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        buf.extend_from_slice(&chunk[..n]);
+                        let mut processed = 0;
+                        let mut i = 0;
+                        while i + 1 < buf.len() {
+                            if buf[i] == 0xFF && buf[i + 1] == 0xD8 {
+                                let start = i;
+                                let mut j = start + 2;
+                                while j + 1 < buf.len() {
+                                    if buf[j] == 0xFF && buf[j + 1] == 0xD9 {
+                                        j += 2;
+                                        let frame = buf[start..j].to_vec();
+                                        if let Ok(mut latest) = frame_ref.lock() {
+                                            *latest = Some(frame);
+                                        }
+                                        processed = j;
+                                        i = j;
+                                        break;
+                                    }
+                                    j += 1;
+                                }
+                                if j >= buf.len() - 1 {
+                                    break;
+                                }
+                            } else {
+                                i += 1;
+                            }
+                        }
+                        if processed > 0 {
+                            buf.drain(0..processed);
+                        } else if buf.len() > 10 * 1024 * 1024 {
+                            buf.clear();
+                        }
+                    }
+                    Err(_) => break,
+                }
+            }
+        });
+
+        thread::sleep(Duration::from_millis(500));
+
+        Ok(CameraPreview {
+            process: Some(child),
+            latest_frame,
+            running,
+            thread_handle: Some(handle),
+        })
+    }
+
+    pub fn get_frame_base64(&self) -> Option<String> {
+        let frame = self.latest_frame.lock().ok()?;
+        frame
+            .as_ref()
+            .map(|data| general_purpose::STANDARD.encode(data))
+    }
+
+    pub fn stop(&mut self) {
+        self.running.store(false, Ordering::Relaxed);
+        if let Some(ref mut child) = self.process {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+        if let Some(handle) = self.thread_handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+impl Drop for CameraPreview {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+pub struct CameraState {
+    pub preview: Mutex<Option<CameraPreview>>,
+}
+
+#[tauri::command]
+pub fn start_camera_preview(
+    device_path: String,
+    state: tauri::State<'_, CameraState>,
+) -> Result<(), String> {
+    let mut preview = state.preview.lock().map_err(|e| e.to_string())?;
+    if let Some(mut old) = preview.take() {
+        old.stop();
+    }
+    *preview = Some(CameraPreview::start(&device_path)?);
+    Ok(())
+}
+
+#[tauri::command]
+pub fn get_preview_frame(state: tauri::State<'_, CameraState>) -> Result<Option<String>, String> {
+    let preview = state.preview.lock().map_err(|e| e.to_string())?;
+    Ok(preview.as_ref().and_then(|p| p.get_frame_base64()))
+}
+
+#[tauri::command]
+pub fn stop_camera_preview(state: tauri::State<'_, CameraState>) -> Result<(), String> {
+    let mut preview = state.preview.lock().map_err(|e| e.to_string())?;
+    if let Some(mut p) = preview.take() {
+        p.stop();
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub fn capture_camera_frame(device_path: String) -> Result<String, String> {
+    let output = Command::new("ffmpeg")
+        .args([
+            "-hide_banner",
+            "-loglevel",
+            "quiet",
+            "-f",
+            "v4l2",
+            "-video_size",
+            "640x480",
+            "-i",
+            &device_path,
+            "-frames:v",
+            "1",
+            "-c:v",
+            "mjpeg",
+            "-q:v",
+            "5",
+            "-f",
+            "image2pipe",
+            "-",
+        ])
+        .output()
+        .map_err(|e| format!("Failed to run ffmpeg: {}. Is ffmpeg installed?", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("Camera capture failed: {}", stderr.trim()));
+    }
+
+    if output.stdout.is_empty() {
+        return Err("Camera returned an empty frame".to_string());
+    }
+
+    Ok(general_purpose::STANDARD.encode(&output.stdout))
+}

--- a/app/src-tauri/src/config.rs
+++ b/app/src-tauri/src/config.rs
@@ -30,6 +30,115 @@ pub struct MethodsConfig {
     pub fingerprint: FingerprintMethodConfig,
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(default)]
+pub struct UnsharpMaskConfig {
+    pub enable: bool,
+    pub amount: f32,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(default)]
+pub struct IRCaptureConfig {
+    pub warmup_frames: i32,
+    pub capture_timeout_ms: i32,
+    pub poll_interval_ms: i32,
+    pub max_attempts: i32,
+    pub agc_sleep_ms: i32,
+    pub camera_warmup_ms: i32,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(default)]
+pub struct CaptureAdvancedConfig {
+    pub width: i32,
+    pub height: i32,
+    pub preview_fps: i32,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(default)]
+pub struct DetectionAdvancedConfig {
+    pub input_size: i32,
+    pub nms_iou_threshold: f32,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(default)]
+pub struct AntiSpoofingAdvancedConfig {
+    pub spoof_class: i32,
+    pub combinational_mode: String,
+    pub debug_save_path: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(default)]
+pub struct EnrollmentAdvancedConfig {
+    pub capture_count: i32,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(default)]
+pub struct RecognitionAdvancedConfig {
+    pub gallery_path: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(default)]
+pub struct AuthAdvancedConfig {
+    pub max_time_ms: i32,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(default)]
+pub struct AdvancedConfig {
+    pub unsharp_mask: UnsharpMaskConfig,
+    pub ir_capture: IRCaptureConfig,
+    pub capture: CaptureAdvancedConfig,
+    pub detection: DetectionAdvancedConfig,
+    pub anti_spoofing: AntiSpoofingAdvancedConfig,
+    pub enrollment: EnrollmentAdvancedConfig,
+    pub recognition: RecognitionAdvancedConfig,
+    pub auth: AuthAdvancedConfig,
+}
+
+impl Default for UnsharpMaskConfig {
+    fn default() -> Self { Self { enable: true, amount: 5.0 } }
+}
+impl Default for IRCaptureConfig {
+    fn default() -> Self { Self { warmup_frames: 3, capture_timeout_ms: 5000, poll_interval_ms: 33, max_attempts: 2, agc_sleep_ms: 500, camera_warmup_ms: 0 } }
+}
+impl Default for CaptureAdvancedConfig {
+    fn default() -> Self { Self { width: 640, height: 480, preview_fps: 3 } }
+}
+impl Default for DetectionAdvancedConfig {
+    fn default() -> Self { Self { input_size: 640, nms_iou_threshold: 0.50 } }
+}
+impl Default for AntiSpoofingAdvancedConfig {
+    fn default() -> Self { Self { spoof_class: 1, combinational_mode: "all".to_string(), debug_save_path: "".to_string() } }
+}
+impl Default for EnrollmentAdvancedConfig {
+    fn default() -> Self { Self { capture_count: 1 } }
+}
+impl Default for RecognitionAdvancedConfig {
+    fn default() -> Self { Self { gallery_path: "".to_string() } }
+}
+impl Default for AuthAdvancedConfig {
+    fn default() -> Self { Self { max_time_ms: 0 } }
+}
+impl Default for AdvancedConfig {
+    fn default() -> Self { Self {
+        unsharp_mask: Default::default(),
+        ir_capture: Default::default(),
+        capture: Default::default(),
+        detection: Default::default(),
+        anti_spoofing: Default::default(),
+        enrollment: Default::default(),
+        recognition: Default::default(),
+        auth: Default::default(),
+    }}
+}
+
 #[derive(Debug, Serialize, Clone)]
 pub struct FaceMethodConfig {
     pub enable: bool,
@@ -38,6 +147,10 @@ pub struct FaceMethodConfig {
     pub detection: DetectionConfig,
     pub recognition: RecognitionConfig,
     pub anti_spoofing: AntiSpoofingConfig,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub camera_device: Option<String>,
+    #[serde(default)]
+    pub advanced: AdvancedConfig,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -75,7 +188,11 @@ struct FaceMethodConfigRaw {
     #[serde(default)]
     pub anti_spoofing: AntiSpoofingConfigRaw,
     #[serde(default)]
+    pub camera_device: Option<String>,
+    #[serde(default)]
     pub ir_camera: Option<LegacyIRCameraConfig>,
+    #[serde(default)]
+    pub advanced: AdvancedConfig,
 }
 
 impl<'de> Deserialize<'de> for FaceMethodConfig {
@@ -102,6 +219,8 @@ impl<'de> Deserialize<'de> for FaceMethodConfig {
             detection: raw.detection,
             recognition: raw.recognition,
             anti_spoofing,
+            camera_device: raw.camera_device,
+            advanced: raw.advanced,
         })
     }
 }
@@ -278,6 +397,8 @@ fn get_default_config(app: &AppHandle) -> BiopassConfig {
                     },
                     ir_camera: None,
                 },
+                camera_device: None,
+                advanced: AdvancedConfig::default(),
             },
             fingerprint: FingerprintMethodConfig {
                 enable: false,

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -1,4 +1,4 @@
-// Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
+pub mod camera;
 pub mod config;
 pub mod face;
 pub mod fingerprint;
@@ -6,6 +6,7 @@ pub mod fingerprint_ffi;
 pub mod paths;
 pub mod system;
 
+use camera::CameraState;
 use config::{load_config, save_config};
 use face::{capture_face, delete_face, list_faces};
 use fingerprint::{
@@ -21,20 +22,47 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_opener::init())
+        .manage(CameraState {
+            preview: std::sync::Mutex::new(None),
+        })
         .setup(|app| {
             #[cfg(target_os = "linux")]
             {
-                use webkit2gtk::{PermissionRequestExt, WebViewExt};
+                use webkit2gtk::{PermissionRequestExt, SettingsExt, WebViewExt};
                 if let Some(window) = app.get_webview_window("main") {
                     let _ = window.with_webview(|webview| {
-                        webview.inner().connect_permission_request(
+                        let inner = webview.inner();
+                        inner.connect_permission_request(
                             |_view, request: &webkit2gtk::PermissionRequest| {
                                 request.allow();
                                 true
                             },
                         );
+
+                        if let Some(settings) = inner.settings() {
+                            settings.set_enable_media_stream(true);
+                            settings.set_enable_webrtc(true);
+                            settings.set_enable_media(true);
+                        }
                     });
                 }
+            }
+
+            // Stop camera preview explicitly when window closes,
+            // ensuring background thread is joined before managed state drops.
+            if let Some(window) = app.get_webview_window("main") {
+                let app_handle = app.handle().clone();
+                window.on_window_event(move |event| {
+                    if let tauri::WindowEvent::Destroyed = event {
+                        if let Some(state) = app_handle.try_state::<CameraState>() {
+                            if let Ok(mut preview) = state.preview.lock() {
+                                if let Some(mut p) = preview.take() {
+                                    p.stop();
+                                }
+                            }
+                        }
+                    }
+                });
             }
 
             Ok(())
@@ -53,7 +81,11 @@ pub fn run() {
             remove_fingerprint,
             fingerprint_is_available,
             list_enrolled_fingerprints,
-            list_fingerprint_devices
+            list_fingerprint_devices,
+            camera::start_camera_preview,
+            camera::get_preview_frame,
+            camera::stop_camera_preview,
+            camera::capture_camera_frame,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/app/src/app/__root.tsx
+++ b/app/src/app/__root.tsx
@@ -6,7 +6,7 @@ import {
 } from "@tanstack/react-router";
 import { TanStackRouterDevtools } from "@tanstack/react-router-devtools";
 import { getCurrentWindow } from "@tauri-apps/api/window";
-import { Cpu, Laptop, Moon, Settings, Sun, User } from "lucide-react";
+import { Cpu, Laptop, Moon, Settings, Sun, User, Wrench } from "lucide-react";
 import { useTheme } from "next-themes";
 import { useEffect, useRef, useState } from "react";
 import logo from "@/assets/logo.png";
@@ -137,6 +137,17 @@ function App() {
                 >
                   <Cpu className="w-4 h-4" />
                   <span className="text-sm font-medium">AI Models</span>
+                </Link>
+                <Link
+                  to="/advanced"
+                  className={`flex items-center gap-2 px-3 py-1.5 rounded-md transition-colors cursor-pointer ${
+                    pathname === "/advanced"
+                      ? "bg-primary/10 text-primary"
+                      : "text-muted-foreground hover:bg-muted hover:text-foreground"
+                  }`}
+                >
+                  <Wrench className="w-4 h-4" />
+                  <span className="text-sm font-medium">Advanced</span>
                 </Link>
               </div>
             </div>

--- a/app/src/app/advanced.tsx
+++ b/app/src/app/advanced.tsx
@@ -1,0 +1,40 @@
+import { createFileRoute } from "@tanstack/react-router";
+import type { AdvancedConfig, FaceMethodConfig } from "@/types/config";
+import { useConfigurationStore } from "../app/configuration/-stores/configuration-store";
+import { AdvancedFaceSettings } from "../app/configuration/-components/face/AdvancedFaceSettings";
+
+function AdvancedRouteComponent() {
+  const config = useConfigurationStore((state) => state.config?.methods.face);
+  const setFaceConfig = useConfigurationStore((state) => state.setFaceConfig);
+
+  if (!config) return null;
+
+  const faceConfig: FaceMethodConfig = config;
+
+  function setAdvancedField<K extends keyof AdvancedConfig>(key: K, value: AdvancedConfig[K]) {
+    setFaceConfig({ ...faceConfig, advanced: { ...faceConfig.advanced, [key]: value } } as FaceMethodConfig);
+  }
+
+  return (
+    <div className="flex flex-col gap-6 w-full max-w-4xl mx-auto p-6">
+      <div>
+        <h1 className="text-3xl font-bold bg-linear-to-r from-primary to-purple-500 bg-clip-text text-transparent">
+          Advanced Settings
+        </h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Tuning parameters for face detection, IR capture, anti-spoofing, and more.
+        </p>
+      </div>
+
+      <AdvancedFaceSettings
+        advanced={config.advanced}
+        onChange={setAdvancedField}
+        alwaysOpen
+      />
+    </div>
+  );
+}
+
+export const Route = createFileRoute("/advanced")({
+  component: AdvancedRouteComponent,
+});

--- a/app/src/app/configuration/-components/face/AdvancedFaceSettings.tsx
+++ b/app/src/app/configuration/-components/face/AdvancedFaceSettings.tsx
@@ -1,0 +1,407 @@
+import { useState } from "react";
+import { ChevronDown, ChevronRight, RotateCcw } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Slider } from "@/components/ui/slider";
+import type { AdvancedConfig } from "@/types/config";
+import { DEFAULT_ADVANCED_CONFIG } from "@/types/config";
+
+interface AdvancedFaceSettingsProps {
+  advanced: AdvancedConfig;
+  onChange: <K extends keyof AdvancedConfig>(key: K, value: AdvancedConfig[K]) => void;
+  alwaysOpen?: boolean;
+}
+
+export function AdvancedFaceSettings({ advanced, onChange, alwaysOpen }: AdvancedFaceSettingsProps) {
+  const [open, setOpen] = useState(alwaysOpen ?? false);
+
+  const sections = (
+    <div className="space-y-6">
+      <div className="flex justify-end">
+        <button
+          type="button"
+          onClick={() => {
+            (Object.keys(DEFAULT_ADVANCED_CONFIG) as Array<keyof AdvancedConfig>).forEach((key) => {
+              onChange(key, DEFAULT_ADVANCED_CONFIG[key]);
+            });
+          }}
+          className="flex items-center gap-1.5 text-sm text-muted-foreground/60 hover:text-foreground transition-colors cursor-pointer"
+          title="Reset all advanced settings to their default values"
+        >
+          <RotateCcw className="w-4 h-4" />
+          Reset all to defaults
+        </button>
+      </div>
+      <UnsharpMaskSection
+        config={advanced.unsharp_mask}
+        defaultConfig={DEFAULT_ADVANCED_CONFIG.unsharp_mask}
+        onChange={(v) => onChange("unsharp_mask", v)}
+      />
+      <IrCaptureSection
+        config={advanced.ir_capture}
+        defaultConfig={DEFAULT_ADVANCED_CONFIG.ir_capture}
+        onChange={(v) => onChange("ir_capture", v)}
+      />
+      <AntiSpoofingAdvancedSection
+        config={advanced.anti_spoofing}
+        defaultConfig={DEFAULT_ADVANCED_CONFIG.anti_spoofing}
+        onChange={(v) => onChange("anti_spoofing", v)}
+      />
+      <DetectionAdvancedSection
+        config={advanced.detection}
+        defaultConfig={DEFAULT_ADVANCED_CONFIG.detection}
+        onChange={(v) => onChange("detection", v)}
+      />
+      <CaptureResolutionSection
+        config={advanced.capture}
+        defaultConfig={DEFAULT_ADVANCED_CONFIG.capture}
+        onChange={(v) => onChange("capture", v)}
+      />
+      <EnrollmentSection
+        config={advanced.enrollment}
+        defaultConfig={DEFAULT_ADVANCED_CONFIG.enrollment}
+        onChange={(v) => onChange("enrollment", v)}
+      />
+      <RecognitionAdvancedSection
+        config={advanced.recognition}
+        defaultConfig={DEFAULT_ADVANCED_CONFIG.recognition}
+        onChange={(v) => onChange("recognition", v)}
+      />
+      <AuthTimeoutSection
+        config={advanced.auth}
+        defaultConfig={DEFAULT_ADVANCED_CONFIG.auth}
+        onChange={(v) => onChange("auth", v)}
+      />
+    </div>
+  );
+
+  if (alwaysOpen) {
+    return sections;
+  }
+
+  return (
+    <div className="p-4 rounded-lg bg-muted/50 border border-border/50 space-y-3">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="flex items-center gap-2 w-full text-left font-medium text-sm cursor-pointer"
+      >
+        {open ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
+        Advanced Settings
+      </button>
+      {open && sections}
+    </div>
+  );
+}
+
+function UnsharpMaskSection({
+  config,
+  defaultConfig,
+  onChange,
+}: {
+  config: AdvancedConfig["unsharp_mask"];
+  defaultConfig: AdvancedConfig["unsharp_mask"];
+  onChange: (v: AdvancedConfig["unsharp_mask"]) => void;
+}) {
+  return (
+    <div className="space-y-3">
+      <SectionHeading label="Unsharp Mask" onReset={() => onChange(defaultConfig)} />
+      <p className="text-sm text-muted-foreground/60">
+        Sharpens face crops before AI anti-spoofing to restore texture detail lost to webcam compression. Disable if using a model trained on soft images.
+      </p>
+      <div className="flex items-center gap-3">
+        <label className="flex items-center gap-2 text-sm cursor-pointer">
+          <input
+            type="checkbox"
+            checked={config.enable}
+            onChange={(e) => onChange({ ...config, enable: e.target.checked })}
+            className="cursor-pointer"
+          />
+          Enable sharpening
+        </label>
+      </div>
+      {config.enable && (
+        <div className="grid gap-2 max-w-48">
+          <div className="flex items-center justify-between">
+            <Label className="text-sm text-muted-foreground">Amount</Label>
+            <span className="text-sm font-mono">{config.amount.toFixed(1)}</span>
+          </div>
+          <Slider
+            value={[config.amount]}
+            min={0}
+            max={15}
+            step={0.5}
+            onValueChange={([v]) => onChange({ ...config, amount: v })}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function IrCaptureSection({
+  config,
+  defaultConfig,
+  onChange,
+}: {
+  config: AdvancedConfig["ir_capture"];
+  defaultConfig: AdvancedConfig["ir_capture"];
+  onChange: (v: AdvancedConfig["ir_capture"]) => void;
+}) {
+  return (
+    <div className="space-y-3">
+      <SectionHeading label="IR Camera Capture" onReset={() => onChange(defaultConfig)} />
+      <p className="text-sm text-muted-foreground/60">
+        Timing and retry behavior for IR frame capture. AGC sleep lets the camera's auto-gain control stabilise between attempts.
+      </p>
+      <div className="grid grid-cols-3 gap-3">
+        <NumberInput label="Warmup Frames" value={config.warmup_frames} min={0} max={100} title="Frames to discard after opening camera (flushes stale buffered frames)" onChange={(v) => onChange({ ...config, warmup_frames: v })} />
+        <NumberInput label="Timeout (ms)" value={config.capture_timeout_ms} min={0} max={30000} step={100} title="Max time to wait for a valid IR frame before giving up" onChange={(v) => onChange({ ...config, capture_timeout_ms: v })} />
+        <NumberInput label="Poll (ms)" value={config.poll_interval_ms} min={1} max={1000} fallback={33} title="Interval between frame availability checks during capture" onChange={(v) => onChange({ ...config, poll_interval_ms: v })} />
+        <NumberInput label="Max Attempts" value={config.max_attempts} min={1} max={10} fallback={1} title="Full capture+detect retries before failing" onChange={(v) => onChange({ ...config, max_attempts: v })} />
+        <NumberInput label="AGC Sleep (ms)" value={config.agc_sleep_ms} min={0} max={10000} step={100} title="Pause between attempts for IR auto-gain-control to stabilise" onChange={(v) => onChange({ ...config, agc_sleep_ms: v })} />
+        <NumberInput label="Cam Warmup (ms)" value={config.camera_warmup_ms} min={0} max={10000} step={100} title="Initial delay after opening camera before any capture attempt" onChange={(v) => onChange({ ...config, camera_warmup_ms: v })} />
+      </div>
+    </div>
+  );
+}
+
+function AntiSpoofingAdvancedSection({
+  config,
+  defaultConfig,
+  onChange,
+}: {
+  config: AdvancedConfig["anti_spoofing"];
+  defaultConfig: AdvancedConfig["anti_spoofing"];
+  onChange: (v: AdvancedConfig["anti_spoofing"]) => void;
+}) {
+  return (
+    <div className="space-y-3">
+      <SectionHeading label="Anti-Spoofing Advanced" onReset={() => onChange(defaultConfig)} />
+      <p className="text-sm text-muted-foreground/60">
+        Spoof class index: which model output class means "spoof" (0 or 1). Combinational mode: "all must pass" (strict) or "any must pass" (relaxed). Debug save path: where failed auth images are saved.
+      </p>
+      <div className="grid grid-cols-3 gap-3">
+        <NumberInput label="Spoof Class Index" value={config.spoof_class} min={0} max={10} title="Which model output class index corresponds to spoof attack" onChange={(v) => onChange({ ...config, spoof_class: v })} />
+        <div className="grid gap-1">
+          <Label className="text-sm text-muted-foreground" title="Whether all anti-spoofing methods must pass, or any one is sufficient">Combinational Mode</Label>
+          <Select
+            value={config.combinational_mode}
+            onValueChange={(v) => onChange({ ...config, combinational_mode: v as "all" | "any" })}
+          >
+            <SelectTrigger className="h-10 text-sm">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All must pass</SelectItem>
+              <SelectItem value="any">Any must pass</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="grid gap-1">
+          <Label className="text-sm text-muted-foreground" title="Directory for saving failed auth debug images (empty = default)">Debug Save Path</Label>
+          <Input
+            type="text"
+            value={config.debug_save_path}
+            onChange={(e) => onChange({ ...config, debug_save_path: e.target.value })}
+            placeholder="(default)"
+            className="h-10 text-sm"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DetectionAdvancedSection({
+  config,
+  defaultConfig,
+  onChange,
+}: {
+  config: AdvancedConfig["detection"];
+  defaultConfig: AdvancedConfig["detection"];
+  onChange: (v: AdvancedConfig["detection"]) => void;
+}) {
+  return (
+    <div className="space-y-3">
+      <SectionHeading label="Detection Advanced" onReset={() => onChange(defaultConfig)} />
+      <p className="text-sm text-muted-foreground/60">
+        YOLOv8 input size (higher = better accuracy, slower). NMS IoU threshold for merging overlapping face boxes — lower = less overlap tolerance.
+      </p>
+      <div className="grid grid-cols-2 gap-3">
+        <NumberInput label="Input Size" value={config.input_size} min={160} max={1920} step={32} fallback={640} title="YOLOv8 network input dimension (width = height)" onChange={(v) => onChange({ ...config, input_size: v })} />
+        <div className="grid gap-1">
+          <div className="flex items-center justify-between">
+            <Label className="text-sm text-muted-foreground" title="Overlap threshold for merging duplicate face boxes (lower = stricter)">NMS IoU</Label>
+            <span className="text-sm font-mono">{(config.nms_iou_threshold * 100).toFixed(0)}%</span>
+          </div>
+          <div className="h-10 flex items-center">
+            <Slider
+              value={[config.nms_iou_threshold]}
+              min={0}
+              max={1}
+              step={0.01}
+              onValueChange={([v]) => onChange({ ...config, nms_iou_threshold: v })}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function CaptureResolutionSection({
+  config,
+  defaultConfig,
+  onChange,
+}: {
+  config: AdvancedConfig["capture"];
+  defaultConfig: AdvancedConfig["capture"];
+  onChange: (v: AdvancedConfig["capture"]) => void;
+}) {
+  return (
+    <div className="space-y-3">
+      <SectionHeading label="Capture Resolution" onReset={() => onChange(defaultConfig)} />
+      <p className="text-sm text-muted-foreground/60">
+        Frame width/height for the RGB camera. Higher = better detection at distance but slower. Preview FPS is controlled from the camera preview bar above.
+      </p>
+      <div className="grid grid-cols-2 gap-3">
+        <NumberInput label="Width" value={config.width} min={160} max={3840} step={16} fallback={640} title="Capture frame width in pixels" onChange={(v) => onChange({ ...config, width: v })} />
+        <NumberInput label="Height" value={config.height} min={120} max={2160} step={16} fallback={480} title="Capture frame height in pixels" onChange={(v) => onChange({ ...config, height: v })} />
+      </div>
+    </div>
+  );
+}
+
+function EnrollmentSection({
+  config,
+  defaultConfig,
+  onChange,
+}: {
+  config: AdvancedConfig["enrollment"];
+  defaultConfig: AdvancedConfig["enrollment"];
+  onChange: (v: AdvancedConfig["enrollment"]) => void;
+}) {
+  return (
+    <div className="space-y-3">
+      <SectionHeading label="Enrollment" onReset={() => onChange(defaultConfig)} />
+      <p className="text-sm text-muted-foreground/60">
+        Number of frames to capture when enrolling a new face. More frames improve recognition robustness at the cost of slower enrollment.
+      </p>
+      <div className="grid grid-cols-1 gap-3 max-w-32">
+        <NumberInput label="Capture Count" value={config.capture_count} min={1} max={20} fallback={1} title="Number of face frames to capture during enrollment" onChange={(v) => onChange({ ...config, capture_count: v })} />
+      </div>
+    </div>
+  );
+}
+
+function RecognitionAdvancedSection({
+  config,
+  defaultConfig,
+  onChange,
+}: {
+  config: AdvancedConfig["recognition"];
+  defaultConfig: AdvancedConfig["recognition"];
+  onChange: (v: AdvancedConfig["recognition"]) => void;
+}) {
+  return (
+    <div className="space-y-3">
+      <SectionHeading label="Recognition Advanced" onReset={() => onChange(defaultConfig)} />
+      <p className="text-sm text-muted-foreground/60">
+        Custom directory for enrolled face images. Leave empty to use the default data directory.
+      </p>
+      <div className="grid grid-cols-1 gap-3">
+        <div className="grid gap-1">
+          <Label className="text-sm text-muted-foreground" title="Custom directory for storing enrolled face images (empty = default)">Gallery Path</Label>
+          <Input
+            type="text"
+            value={config.gallery_path}
+            onChange={(e) => onChange({ ...config, gallery_path: e.target.value })}
+            placeholder="(default data dir)"
+            className="h-10 text-sm"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function AuthTimeoutSection({
+  config,
+  defaultConfig,
+  onChange,
+}: {
+  config: AdvancedConfig["auth"];
+  defaultConfig: AdvancedConfig["auth"];
+  onChange: (v: AdvancedConfig["auth"]) => void;
+}) {
+  return (
+    <div className="space-y-3">
+      <SectionHeading label="Authentication Timeout" onReset={() => onChange(defaultConfig)} />
+      <p className="text-sm text-muted-foreground/60">
+        Hard cap on total authentication time in milliseconds. 0 = auto (computed from retries × retry delay + 5s margin).
+      </p>
+      <div className="grid grid-cols-1 gap-3 max-w-48">
+        <NumberInput label="Max Auth Time (ms, 0 = auto)" value={config.max_time_ms} min={0} max={60000} step={100} fallback={0} title="Absolute timeout for entire authentication (0 = auto from retries \u00d7 delay + margin)" onChange={(v) => onChange({ ...config, max_time_ms: v })} />
+      </div>
+    </div>
+  );
+}
+
+function SectionHeading({ label, onReset }: { label: string; onReset: () => void }) {
+  return (
+    <h5 className="text-sm font-medium text-muted-foreground flex items-center gap-2">
+      <span>{label}</span>
+      <button
+        type="button"
+        onClick={onReset}
+        className="inline-flex items-center text-muted-foreground/30 hover:text-foreground transition-colors cursor-pointer"
+        title="Reset this section to defaults"
+      >
+        <RotateCcw className="w-4 h-4" />
+      </button>
+    </h5>
+  );
+}
+
+function NumberInput({
+  label,
+  value,
+  min,
+  max,
+  step,
+  fallback,
+  title,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  step?: number;
+  fallback?: number;
+  title?: string;
+  onChange: (v: number) => void;
+}) {
+  return (
+    <div className="grid gap-1">
+      <Label className="text-sm text-muted-foreground" title={title}>{label}</Label>
+      <Input
+        type="number"
+        min={min}
+        max={max}
+        step={step ?? 1}
+        value={value}
+        onChange={(e) => onChange(parseInt(e.target.value, 10) || (fallback ?? 0))}
+        className="h-10 text-sm"
+      />
+    </div>
+  );
+}

--- a/app/src/app/configuration/-components/face/FaceCapture.tsx
+++ b/app/src/app/configuration/-components/face/FaceCapture.tsx
@@ -1,42 +1,40 @@
 import { convertFileSrc } from "@tauri-apps/api/core";
-import { Camera, Circle, Square, Trash2 } from "lucide-react";
+import { Camera, Circle, Square, Trash2, AlertCircle } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { cmd } from "@/commands";
 import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 
-function stopMediaStream(stream: MediaStream | null) {
-  if (!stream) return;
+const FPS_OPTIONS = [
+  { label: "3 FPS", interval: 300, fps: 3 },
+  { label: "15 FPS", interval: 66, fps: 15 },
+  { label: "30 FPS", interval: 33, fps: 30 },
+] as const;
 
-  for (const track of stream.getTracks()) {
-    track.stop();
-  }
+function fpsToIndex(fps: number): number {
+  const idx = FPS_OPTIONS.findIndex((o) => o.fps === fps);
+  return idx >= 0 ? idx : 0;
 }
 
-async function openCamera(deviceId?: string) {
-  const video = deviceId
-    ? {
-        width: 640,
-        height: 480,
-        deviceId: { exact: deviceId },
-      }
-    : {
-        width: 640,
-        height: 480,
-      };
-
-  return navigator.mediaDevices.getUserMedia({ video });
-}
-
-export function FaceCapture() {
-  const videoRef = useRef<HTMLVideoElement>(null);
-  const canvasRef = useRef<HTMLCanvasElement>(null);
-  const [stream, setStream] = useState<MediaStream | null>(null);
+export function FaceCapture({ selectedDevicePath, previewFps, onPreviewFpsChange }: {
+  selectedDevicePath?: string;
+  previewFps?: number;
+  onPreviewFpsChange?: (fps: number) => void;
+}) {
+  const nativeImgRef = useRef<HTMLImageElement>(null);
+  const pollingRef = useRef<number | null>(null);
   const [capturing, setCapturing] = useState(false);
   const [faceImages, setFaceImages] = useState<string[]>([]);
-  const [activeBrowserCameraLabel, setActiveBrowserCameraLabel] = useState<
-    string | null
-  >(null);
+  const [nativeFrame, setNativeFrame] = useState<string | null>(null);
+  const [fpsIndex, setFpsIndex] = useState(fpsToIndex(previewFps ?? 3));
+  const capturedFrameRef = useRef<string | null>(null);
 
   const loadFaceImages = useCallback(async () => {
     try {
@@ -53,67 +51,71 @@ export function FaceCapture() {
 
   useEffect(() => {
     return () => {
-      stopMediaStream(stream);
+      stopPolling();
+      cmd.face.stopCameraPreview().catch(() => {});
     };
-  }, [stream]);
+  }, []);
 
-  // Attach stream to video element when stream changes
-  useEffect(() => {
-    if (!videoRef.current) {
-      return;
+  function stopPolling() {
+    if (pollingRef.current !== null) {
+      clearInterval(pollingRef.current);
+      pollingRef.current = null;
     }
+  }
 
-    if (!stream) {
-      videoRef.current.srcObject = null;
-      return;
-    }
-
-    videoRef.current.srcObject = stream;
-    videoRef.current.play().catch(console.error);
-  }, [stream]);
+  async function pollFrames() {
+    stopPolling();
+    const interval = FPS_OPTIONS[fpsIndex].interval;
+    pollingRef.current = window.setInterval(async () => {
+      try {
+        const frame = await cmd.face.getPreviewFrame();
+        if (frame) {
+          capturedFrameRef.current = frame;
+          setNativeFrame(`data:image/jpeg;base64,${frame}`);
+        }
+      } catch {
+        // frame read failed, will retry
+      }
+    }, interval);
+  }
 
   async function startCamera() {
-    let mediaStream: MediaStream | null = null;
-
     try {
-      mediaStream = await openCamera();
-
-      const activeTrackLabel = mediaStream.getVideoTracks()[0]?.label?.trim();
-
-      stopMediaStream(stream);
-      setStream(mediaStream);
-      setActiveBrowserCameraLabel(activeTrackLabel || null);
+      let device = selectedDevicePath;
+      if (!device) {
+        const devices = await cmd.face.listVideoDevices();
+        const target = devices.find(
+          (d) => !d.name.toLowerCase().includes("metadata"),
+        );
+        device = target?.path ?? "/dev/video0";
+      }
+      await cmd.face.startCameraPreview(device);
+      pollFrames();
       setCapturing(true);
     } catch (err) {
-      stopMediaStream(mediaStream);
-      setActiveBrowserCameraLabel(null);
       toast.error("Failed to access camera");
       console.error(err);
     }
   }
 
   function stopCamera() {
-    stopMediaStream(stream);
-    setStream(null);
-    setActiveBrowserCameraLabel(null);
+    stopPolling();
     setCapturing(false);
+    setNativeFrame(null);
+    capturedFrameRef.current = null;
+    cmd.face.stopCameraPreview().catch(() => {});
   }
 
   async function capturePhoto() {
-    if (!videoRef.current || !canvasRef.current) return;
+    const frame = capturedFrameRef.current;
+    if (!frame) {
+      toast.error("No frame available yet, please wait...");
+      return;
+    }
+    await saveFaceImage(frame);
+  }
 
-    const video = videoRef.current;
-    const canvas = canvasRef.current;
-    canvas.width = video.videoWidth;
-    canvas.height = video.videoHeight;
-
-    const ctx = canvas.getContext("2d");
-    if (!ctx) return;
-
-    ctx.drawImage(video, 0, 0);
-    const dataUrl = canvas.toDataURL("image/jpeg", 0.9);
-    const base64Data = dataUrl.split(",")[1];
-
+  async function saveFaceImage(base64Data: string) {
     try {
       await cmd.face.saveImage(base64Data);
       toast.success("Face image saved!");
@@ -141,24 +143,60 @@ export function FaceCapture() {
       </h4>
 
       <div className="grid gap-4">
-        {/* Camera Preview */}
         <div className="relative aspect-video bg-black rounded-lg overflow-hidden">
-          <video
-            ref={videoRef}
-            autoPlay
-            playsInline
-            muted
-            className={`w-full h-full object-cover ${capturing ? "" : "hidden"}`}
-          />
-          {!capturing && (
+          {nativeFrame && capturing ? (
+            <img
+              ref={nativeImgRef}
+              src={nativeFrame}
+              alt="Camera preview"
+              className="w-full h-full object-cover"
+            />
+          ) : !capturing ? (
             <div className="absolute inset-0 flex items-center justify-center text-muted-foreground">
               <Camera className="w-12 h-12 opacity-50" />
             </div>
+          ) : (
+            <div className="absolute inset-0 flex items-center justify-center text-muted-foreground">
+              <div className="text-center">
+                <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-primary mx-auto mb-2" />
+                <p className="text-xs">Starting camera...</p>
+              </div>
+            </div>
           )}
-          <canvas ref={canvasRef} className="hidden" />
         </div>
 
-        {/* Controls */}
+        <div className="flex items-center gap-2 text-xs text-amber-500 bg-amber-500/10 p-2 rounded">
+          <AlertCircle className="w-3 h-3 shrink-0" />
+          <span className="flex-1">
+            Using native camera capture —{" "}
+            {capturing
+              ? `${FPS_OPTIONS[fpsIndex].label}`
+              : "preview not started"}
+          </span>
+          <Select
+            value={String(fpsIndex)}
+            onValueChange={(v) => {
+              const idx = Number(v);
+              setFpsIndex(idx);
+              if (onPreviewFpsChange) {
+                onPreviewFpsChange(FPS_OPTIONS[idx].fps);
+              }
+              if (capturing) pollFrames();
+            }}
+          >
+            <SelectTrigger className="h-6 text-xs w-20 border-amber-500/30">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {FPS_OPTIONS.map((opt, i) => (
+                <SelectItem key={i} value={String(i)}>
+                  {opt.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
         <div className="flex gap-2">
           {!capturing ? (
             <Button onClick={startCamera} className="flex-1">
@@ -179,15 +217,6 @@ export function FaceCapture() {
           )}
         </div>
 
-        {capturing && (
-          <p className="text-[10px] text-muted-foreground">
-            {activeBrowserCameraLabel
-              ? `Browser preview camera: ${activeBrowserCameraLabel}`
-              : "Browser preview camera: active, but WebKit did not expose a device label."}
-          </p>
-        )}
-
-        {/* Saved Faces */}
         {faceImages.length > 0 && (
           <div>
             <p className="text-sm text-muted-foreground mb-2">

--- a/app/src/app/configuration/-components/face/FaceSetting.tsx
+++ b/app/src/app/configuration/-components/face/FaceSetting.tsx
@@ -9,7 +9,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import type { VideoDeviceInfo } from "@/types/config";
+import type { AdvancedConfig, FaceMethodConfig, VideoDeviceInfo } from "@/types/config";
 import { useConfigurationStore } from "../../-stores/configuration-store";
 import { ModelSelect } from "../methods/shared/ModelSelect";
 import { Threshold } from "../methods/shared/Threshold";
@@ -33,6 +33,13 @@ export function FaceSetting() {
     fetchDevices();
   }, []);
 
+  const selectedCameraDevice = useMemo(() => {
+    if (!config) return null;
+    const cameraDevice = config.camera_device;
+    if (!cameraDevice) return null;
+    return videoDevices.find((device) => device.path === cameraDevice) ?? null;
+  }, [config, videoDevices]);
+
   const selectedIrCamera = useMemo(() => {
     if (!config) return null;
     const irCameraPath = config.anti_spoofing.ir_camera;
@@ -45,6 +52,12 @@ export function FaceSetting() {
   );
 
   if (!config) return null;
+
+  const faceConfig: FaceMethodConfig = config;
+
+  function setAdvancedField<K extends keyof AdvancedConfig>(key: K, value: AdvancedConfig[K]) {
+    setFaceConfig({ ...faceConfig, advanced: { ...faceConfig.advanced, [key]: value } } as FaceMethodConfig);
+  }
 
   const disabledOption = "__disabled__";
   const unavailableAiModelOption = "__unavailable_ai_model__";
@@ -111,7 +124,43 @@ export function FaceSetting() {
         </div>
       </div>
 
-      <FaceCapture />
+      <div className="grid gap-2">
+        <Label htmlFor="camera-device" className="text-xs text-muted-foreground">
+          Camera Device
+        </Label>
+        <Select
+          value={config.camera_device ?? "__default__"}
+          onValueChange={(value) => {
+            setFaceConfig({
+              ...config,
+              camera_device: value === "__default__" ? null : value,
+            });
+          }}
+        >
+          <SelectTrigger id="camera-device" className="h-10 w-full">
+            <SelectValue placeholder="Select Camera Device" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__default__">Default (auto)</SelectItem>
+            {videoDevices.map((device) => (
+              <SelectItem key={device.path} value={device.path}>
+                {device.display_name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <FaceCapture
+        selectedDevicePath={selectedCameraDevice?.path}
+        previewFps={config.advanced.capture.preview_fps}
+        onPreviewFpsChange={(fps) =>
+          setAdvancedField("capture", {
+            ...config.advanced.capture,
+            preview_fps: fps,
+          })
+        }
+      />
 
       <div className="p-4 rounded-lg bg-muted/50 border border-border/50">
         <h4 className="font-medium mb-3 text-sm">Detection</h4>
@@ -293,6 +342,7 @@ export function FaceSetting() {
           </Select>
         </div>
       </div>
+
     </div>
   );
 }

--- a/app/src/commands/face.ts
+++ b/app/src/commands/face.ts
@@ -17,9 +17,33 @@ function listVideoDevices() {
   return invokeCommand<VideoDeviceInfo[]>("list_video_devices");
 }
 
+function captureCameraFrame(devicePath: string) {
+  return invokeCommand<string>("capture_camera_frame", {
+    devicePath,
+  });
+}
+
+function startCameraPreview(devicePath: string) {
+  return invokeCommand<void>("start_camera_preview", {
+    devicePath,
+  });
+}
+
+function getPreviewFrame() {
+  return invokeCommand<string | null>("get_preview_frame");
+}
+
+function stopCameraPreview() {
+  return invokeCommand<void>("stop_camera_preview");
+}
+
 export const face = {
   listImages,
   saveImage,
   deleteImage,
   listVideoDevices,
+  captureCameraFrame,
+  startCameraPreview,
+  getPreviewFrame,
+  stopCameraPreview,
 };

--- a/app/src/routeTree.gen.ts
+++ b/app/src/routeTree.gen.ts
@@ -10,12 +10,18 @@
 
 import { Route as rootRouteImport } from './app/__root'
 import { Route as ModelsRouteImport } from './app/models'
+import { Route as AdvancedRouteImport } from './app/advanced'
 import { Route as PageRouteImport } from './app/page'
 import { Route as ConfigurationPageRouteImport } from './app/configuration/page'
 
 const ModelsRoute = ModelsRouteImport.update({
   id: '/models',
   path: '/models',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AdvancedRoute = AdvancedRouteImport.update({
+  id: '/advanced',
+  path: '/advanced',
   getParentRoute: () => rootRouteImport,
 } as any)
 const PageRoute = PageRouteImport.update({
@@ -31,30 +37,34 @@ const ConfigurationPageRoute = ConfigurationPageRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof PageRoute
+  '/advanced': typeof AdvancedRoute
   '/models': typeof ModelsRoute
   '/configuration/': typeof ConfigurationPageRoute
 }
 export interface FileRoutesByTo {
   '/': typeof PageRoute
+  '/advanced': typeof AdvancedRoute
   '/models': typeof ModelsRoute
   '/configuration': typeof ConfigurationPageRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof PageRoute
+  '/advanced': typeof AdvancedRoute
   '/models': typeof ModelsRoute
   '/configuration/': typeof ConfigurationPageRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/models' | '/configuration/'
+  fullPaths: '/' | '/advanced' | '/models' | '/configuration/'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/models' | '/configuration'
-  id: '__root__' | '/' | '/models' | '/configuration/'
+  to: '/' | '/advanced' | '/models' | '/configuration'
+  id: '__root__' | '/' | '/advanced' | '/models' | '/configuration/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   PageRoute: typeof PageRoute
+  AdvancedRoute: typeof AdvancedRoute
   ModelsRoute: typeof ModelsRoute
   ConfigurationPageRoute: typeof ConfigurationPageRoute
 }
@@ -66,6 +76,13 @@ declare module '@tanstack/react-router' {
       path: '/models'
       fullPath: '/models'
       preLoaderRoute: typeof ModelsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/advanced': {
+      id: '/advanced'
+      path: '/advanced'
+      fullPath: '/advanced'
+      preLoaderRoute: typeof AdvancedRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/': {
@@ -87,6 +104,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   PageRoute: PageRoute,
+  AdvancedRoute: AdvancedRoute,
   ModelsRoute: ModelsRoute,
   ConfigurationPageRoute: ConfigurationPageRoute,
 }

--- a/app/src/types/config.ts
+++ b/app/src/types/config.ts
@@ -23,6 +23,71 @@ export interface VideoDeviceInfo {
   display_name: string;
 }
 
+export interface UnsharpMaskConfig {
+  enable: boolean;
+  amount: number;
+}
+
+export interface IRCaptureConfig {
+  warmup_frames: number;
+  capture_timeout_ms: number;
+  poll_interval_ms: number;
+  max_attempts: number;
+  agc_sleep_ms: number;
+  camera_warmup_ms: number;
+}
+
+export interface CaptureAdvancedConfig {
+  width: number;
+  height: number;
+  preview_fps: number;
+}
+
+export interface DetectionAdvancedConfig {
+  input_size: number;
+  nms_iou_threshold: number;
+}
+
+export interface AntiSpoofingAdvancedConfig {
+  spoof_class: number;
+  combinational_mode: "all" | "any";
+  debug_save_path: string;
+}
+
+export interface EnrollmentAdvancedConfig {
+  capture_count: number;
+}
+
+export interface RecognitionAdvancedConfig {
+  gallery_path: string;
+}
+
+export interface AuthAdvancedConfig {
+  max_time_ms: number;
+}
+
+export const DEFAULT_ADVANCED_CONFIG: AdvancedConfig = {
+  unsharp_mask: { enable: true, amount: 5.0 },
+  ir_capture: { warmup_frames: 3, capture_timeout_ms: 5000, poll_interval_ms: 33, max_attempts: 2, agc_sleep_ms: 500, camera_warmup_ms: 0 },
+  capture: { width: 640, height: 480, preview_fps: 3 },
+  detection: { input_size: 640, nms_iou_threshold: 0.50 },
+  anti_spoofing: { spoof_class: 1, combinational_mode: "all", debug_save_path: "" },
+  enrollment: { capture_count: 1 },
+  recognition: { gallery_path: "" },
+  auth: { max_time_ms: 0 },
+};
+
+export interface AdvancedConfig {
+  unsharp_mask: UnsharpMaskConfig;
+  ir_capture: IRCaptureConfig;
+  capture: CaptureAdvancedConfig;
+  detection: DetectionAdvancedConfig;
+  anti_spoofing: AntiSpoofingAdvancedConfig;
+  enrollment: EnrollmentAdvancedConfig;
+  recognition: RecognitionAdvancedConfig;
+  auth: AuthAdvancedConfig;
+}
+
 export interface FaceMethodConfig {
   enable: boolean;
   retries: number;
@@ -43,6 +108,8 @@ export interface FaceMethodConfig {
     };
     ir_camera: string | null;
   };
+  camera_device: string | null;
+  advanced: AdvancedConfig;
 }
 
 export interface FingerprintMethodConfig {

--- a/auth/core/auth_config.cc
+++ b/auth/core/auth_config.cc
@@ -38,6 +38,68 @@ std::string user_data_dir(const std::string& username) {
   return "";
 }
 
+static void parseAdvancedConfig(const YAML::Node& adv, AdvancedConfig& out) {
+  if (!adv || !adv.IsMap()) return;
+
+  // Unsharp mask
+  if (adv["unsharp_mask"]) {
+    const auto& us = adv["unsharp_mask"];
+    if (us["enable"])           out.unsharp_mask.enable = us["enable"].as<bool>();
+    if (us["amount"])           out.unsharp_mask.amount = us["amount"].as<float>();
+  }
+
+  // IR capture
+  if (adv["ir_capture"]) {
+    const auto& ir = adv["ir_capture"];
+    if (ir["warmup_frames"])    out.ir_capture.warmup_frames = ir["warmup_frames"].as<int>();
+    if (ir["capture_timeout_ms"])  out.ir_capture.capture_timeout_ms = ir["capture_timeout_ms"].as<int>();
+    if (ir["poll_interval_ms"]) out.ir_capture.poll_interval_ms = ir["poll_interval_ms"].as<int>();
+    if (ir["max_attempts"])     out.ir_capture.max_attempts = ir["max_attempts"].as<int>();
+    if (ir["agc_sleep_ms"])     out.ir_capture.agc_sleep_ms = ir["agc_sleep_ms"].as<int>();
+    if (ir["camera_warmup_ms"]) out.ir_capture.camera_warmup_ms = ir["camera_warmup_ms"].as<int>();
+  }
+
+  // Capture
+  if (adv["capture"]) {
+    const auto& cap = adv["capture"];
+    if (cap["width"])           out.capture.width = cap["width"].as<int>();
+    if (cap["height"])          out.capture.height = cap["height"].as<int>();
+  }
+
+  // Detection
+  if (adv["detection"]) {
+    const auto& det = adv["detection"];
+    if (det["input_size"])      out.detection.input_size = det["input_size"].as<int>();
+    if (det["nms_iou_threshold"])  out.detection.nms_iou_threshold = det["nms_iou_threshold"].as<float>();
+  }
+
+  // Anti-spoofing
+  if (adv["anti_spoofing"]) {
+    const auto& as_ = adv["anti_spoofing"];
+    if (as_["spoof_class"])     out.anti_spoofing.spoof_class = as_["spoof_class"].as<int>();
+    if (as_["combinational_mode"])  out.anti_spoofing.combinational_mode = as_["combinational_mode"].as<std::string>();
+    if (as_["debug_save_path"]) out.anti_spoofing.debug_save_path = as_["debug_save_path"].as<std::string>();
+  }
+
+  // Enrollment
+  if (adv["enrollment"]) {
+    const auto& enr = adv["enrollment"];
+    if (enr["capture_count"])   out.enrollment.capture_count = enr["capture_count"].as<int>();
+  }
+
+  // Recognition
+  if (adv["recognition"]) {
+    const auto& rec = adv["recognition"];
+    if (rec["gallery_path"])    out.recognition.gallery_path = rec["gallery_path"].as<std::string>();
+  }
+
+  // Auth
+  if (adv["auth"]) {
+    const auto& a = adv["auth"];
+    if (a["max_time_ms"])       out.auth.max_time_ms = a["max_time_ms"].as<int>();
+  }
+}
+
 BiopassConfig readConfig(const std::string& username) {
   BiopassConfig config;
 
@@ -121,6 +183,10 @@ BiopassConfig readConfig(const std::string& username) {
           if (f["recognition"]["threshold"])
             config.methods.face.recognition.threshold = f["recognition"]["threshold"].as<float>();
         }
+        if (f["camera_device"] && !f["camera_device"].IsNull()) {
+          config.methods.face.camera_device = f["camera_device"].as<std::string>();
+        }
+
         if (f["anti_spoofing"]) {
           const auto& anti_spoofing = f["anti_spoofing"];
           if (anti_spoofing["enable"]) {
@@ -152,6 +218,8 @@ BiopassConfig readConfig(const std::string& username) {
             config.methods.face.anti_spoofing.ir_camera = anti_spoofing["ir_camera"].as<std::string>();
           }
         }
+
+        parseAdvancedConfig(f["advanced"], config.methods.face.advanced);
 
         // Backward compatibility with old schema:
         // methods.face.ir_camera.enable + methods.face.ir_camera.device_id

--- a/auth/core/auth_config.h
+++ b/auth/core/auth_config.h
@@ -48,6 +48,64 @@ struct AntiSpoofingConfig {
   std::optional<std::string> ir_camera = std::nullopt;
 };
 
+// ---------------------------------------------------------------------------
+// Advanced / expert config (optional section under methods.face.advanced)
+// ---------------------------------------------------------------------------
+
+struct UnsharpMaskConfig {
+  bool enable = true;
+  float amount = 5.0f;
+};
+
+struct IRCaptureConfig {
+  int warmup_frames = 3;
+  int capture_timeout_ms = 5000;
+  int poll_interval_ms = 33;
+  int max_attempts = 2;
+  int agc_sleep_ms = 500;
+  int camera_warmup_ms = 0;
+};
+
+struct CaptureConfig {
+  int width = 640;
+  int height = 480;
+  int preview_fps = 3;
+};
+
+struct DetectionAdvancedConfig {
+  int input_size = 640;
+  float nms_iou_threshold = 0.50f;
+};
+
+struct AntiSpoofingAdvancedConfig {
+  int spoof_class = 1;
+  std::string combinational_mode = "all";  // "all" | "any"
+  std::string debug_save_path = "";
+};
+
+struct EnrollmentConfig {
+  int capture_count = 1;
+};
+
+struct RecognitionAdvancedConfig {
+  std::string gallery_path = "";
+};
+
+struct AuthAdvancedConfig {
+  int max_time_ms = 0;  // 0 = compute from retries * retry_delay
+};
+
+struct AdvancedConfig {
+  UnsharpMaskConfig unsharp_mask;
+  IRCaptureConfig ir_capture;
+  CaptureConfig capture;
+  DetectionAdvancedConfig detection;
+  AntiSpoofingAdvancedConfig anti_spoofing;
+  EnrollmentConfig enrollment;
+  RecognitionAdvancedConfig recognition;
+  AuthAdvancedConfig auth;
+};
+
 struct FaceMethodConfig {
   bool enable = true;
   uint32_t retries = 5;
@@ -55,6 +113,8 @@ struct FaceMethodConfig {
   DetectionConfig detection;
   RecognitionConfig recognition;
   AntiSpoofingConfig anti_spoofing;
+  std::optional<std::string> camera_device = std::nullopt;
+  AdvancedConfig advanced;
 };
 
 struct FingerConfig {

--- a/auth/core/auth_method.h
+++ b/auth/core/auth_method.h
@@ -20,6 +20,7 @@ struct IAuthMethod {
   virtual bool isAvailable() const = 0;
   virtual uint32_t getRetries() const = 0;
   virtual uint32_t getRetryDelayMs() const = 0;
+  virtual uint32_t getMaxAuthTimeMs() const { return 0; }
   virtual void beginAuthenticationSession() {}
   virtual void endAuthenticationSession() {}
   virtual AuthResult authenticate(const std::string& username, const AuthConfig& config,

--- a/auth/face/antispoofing/antispoof_check.cc
+++ b/auth/face/antispoofing/antispoof_check.cc
@@ -26,6 +26,14 @@ AntiSpoofTask make_task(const std::string& name, std::future<bool> future) {
   return task;
 }
 
+std::string resolveDebugPath(const std::string& username,
+                             const std::string& configured_path) {
+  if (!configured_path.empty()) {
+    return configured_path;
+  }
+  return getDebugPath(username);
+}
+
 bool checkAntiSpoofByAIModel(const FaceMethodConfig& faceCfg, const std::string& username,
                              const ImageRGB& face, const AuthConfig& authCfg) {
   const std::string modelPath = faceCfg.anti_spoofing.model.path;
@@ -35,7 +43,12 @@ bool checkAntiSpoofByAIModel(const FaceMethodConfig& faceCfg, const std::string&
   }
 
   try {
-    FaceAntiSpoofing face_as(modelPath, 128, faceCfg.anti_spoofing.model.threshold);
+    UnsharpMaskParams unsharp;
+    unsharp.enable = faceCfg.advanced.unsharp_mask.enable;
+    unsharp.amount = faceCfg.advanced.unsharp_mask.amount;
+
+    FaceAntiSpoofing face_as(modelPath, 128, faceCfg.anti_spoofing.model.threshold,
+                             faceCfg.advanced.anti_spoofing.spoof_class, unsharp);
     const SpoofResult result = face_as.inference(face);
     if (result.spoof) {
       spdlog::warn("FaceAuth: AI anti-spoofing detected spoof, score: {}", result.score);
@@ -71,7 +84,11 @@ bool checkAntiSpoof(const FaceMethodConfig& face_config, const std::string& user
                 ai_enabled, ir_enabled,
                 face_config.anti_spoofing.ir_camera.value_or(""));
 
+  const bool any_mode = face_config.advanced.anti_spoofing.combinational_mode == "any";
+
   std::vector<AntiSpoofTask> tasks;
+  int passed = 0;
+  int failed = 0;
 
   if (ai_enabled) {
     const auto face_config_copy = face_config;
@@ -92,18 +109,19 @@ bool checkAntiSpoof(const FaceMethodConfig& face_config, const std::string& user
     const auto detection_threshold = face_config.detection.threshold;
     const auto username_copy = username;
     const auto debug_enabled = config.debug;
+    const auto ir_params = face_config.advanced.ir_capture;
     auto* ir_camera_session_ptr = ir_camera_session;
     tasks.push_back(make_task(
         "IR", std::async(std::launch::async,
                          [ir_camera_path, detection_model, detection_threshold, username_copy,
-                          debug_enabled, ir_camera_session_ptr]() {
+                          debug_enabled, ir_camera_session_ptr, ir_params]() {
                            return checkAntispoofByIRCamera(ir_camera_path, detection_model,
                                                            detection_threshold, username_copy,
-                                                           debug_enabled, ir_camera_session_ptr);
-        })));
+                                                           debug_enabled, ir_camera_session_ptr,
+                                                           ir_params);
+                         })));
   }
 
-  bool all_passed = true;
   for (auto& task : tasks) {
     bool ok = false;
     try {
@@ -114,16 +132,30 @@ bool checkAntiSpoof(const FaceMethodConfig& face_config, const std::string& user
     }
     if (ok) {
       spdlog::debug("FaceAuth: {} anti-spoofing method passed", task.name);
+      passed++;
     } else {
       spdlog::debug("FaceAuth: {} anti-spoofing method failed", task.name);
-      all_passed = false;
+      failed++;
     }
   }
 
-  if (!all_passed) {
-    spdlog::error("FaceAuth: Anti-spoofing failed (one or more enabled methods failed)");
+  if (any_mode) {
+    // Any one method passing is enough
+    if (passed > 0) {
+      spdlog::debug("FaceAuth: Anti-spoofing passed (any mode, {} passed, {} failed)", passed, failed);
+      return true;
+    }
+    spdlog::error("FaceAuth: Anti-spoofing failed (any mode, {} passed, {} failed)", passed, failed);
+    return false;
   }
-  return all_passed;
+
+  // All mode (default): all methods must pass
+  if (failed > 0) {
+    spdlog::error("FaceAuth: Anti-spoofing failed (all mode, {} passed, {} failed)", passed, failed);
+    return false;
+  }
+  spdlog::debug("FaceAuth: Anti-spoofing passed (all mode, {} methods)", passed);
+  return true;
 }
 
 }  // namespace biopass

--- a/auth/face/antispoofing/face_as.cc
+++ b/auth/face/antispoofing/face_as.cc
@@ -12,10 +12,14 @@ int argmax(const float* data, int size) {
   return max_index;
 }
 
-FaceAntiSpoofing::FaceAntiSpoofing(const std::string& ckpt, int imgsz, const float threshold) {
+FaceAntiSpoofing::FaceAntiSpoofing(const std::string& ckpt, int imgsz, const float threshold,
+                                   int spoof_class_index,
+                                   const UnsharpMaskParams& unsharp) {
   this->ckpt = ckpt;
   this->imgsz = imgsz;
   this->threshold = threshold;
+  this->spoof_class_index_ = spoof_class_index;
+  this->unsharp_params_ = unsharp;
   this->loadModel(ckpt);
 }
 
@@ -51,7 +55,10 @@ std::vector<float> FaceAntiSpoofing::preprocess(const ImageRGB& input_image) {
   const float mean[3] = {0.5931f, 0.4690f, 0.4229f};
   const float std[3] = {0.2471f, 0.2214f, 0.2157f};
   ImageRGB resize_img = resizeImage(input_image, this->imgsz, this->imgsz);
-
+  if (this->unsharp_params_.enable) {
+    ImageRGB sharpened = sharpenImage(resize_img, this->unsharp_params_.amount);
+    return imageToChwNormalized(sharpened, mean, std);
+  }
   return imageToChwNormalized(resize_img, mean, std);
 }
 
@@ -71,5 +78,5 @@ SpoofResult FaceAntiSpoofing::inference(const ImageRGB& image) {
 
   int spoof_cls = argmax(logits, 2);
   float score = logits[spoof_cls];
-  return SpoofResult(score, spoof_cls == 0 && score >= this->threshold);
+  return SpoofResult(score, spoof_cls == this->spoof_class_index_ && score >= this->threshold);
 }

--- a/auth/face/antispoofing/face_as.h
+++ b/auth/face/antispoofing/face_as.h
@@ -16,9 +16,16 @@ struct SpoofResult {
   SpoofResult(float score, bool spoof) : score(score), spoof(spoof) {}
 };
 
+struct UnsharpMaskParams {
+  bool enable = true;
+  float amount = 5.0f;
+};
+
 class FaceAntiSpoofing {
  public:
-  FaceAntiSpoofing(const std::string& ckpt, int imgsz = 128, const float threshold = 0.8);
+  FaceAntiSpoofing(const std::string& ckpt, int imgsz = 128, const float threshold = 0.8,
+                   int spoof_class_index = 1,
+                   const UnsharpMaskParams& unsharp = UnsharpMaskParams{});
 
   void loadModel(const std::string& ckpt);
   SpoofResult inference(const ImageRGB& image);
@@ -28,6 +35,8 @@ class FaceAntiSpoofing {
   std::string ckpt;
   float threshold;
   int imgsz;
+  int spoof_class_index_;
+  UnsharpMaskParams unsharp_params_;
 
   Ort::Env env{ORT_LOGGING_LEVEL_WARNING, "FaceAntiSpoofing"};
   std::unique_ptr<Ort::Session> session;

--- a/auth/face/antispoofing/ir_camera_as.cc
+++ b/auth/face/antispoofing/ir_camera_as.cc
@@ -3,8 +3,10 @@
 #include <spdlog/spdlog.h>
 
 #include <algorithm>
+#include <chrono>
 #include <cmath>
 #include <fstream>
+#include <thread>
 
 #include "camera_capture.h"
 #include "debug_image_io.h"
@@ -12,18 +14,11 @@
 
 namespace biopass {
 
-namespace {
-
-constexpr int kIrCaptureWarmupFrames = 5;
-constexpr int kIrCaptureTimeoutMs = 3000;
-constexpr int kIrCapturePollIntervalMs = 10;
-
-}  // namespace
-
 bool checkAntispoofByIRCamera(const std::string& device_path,
                               const std::string& detection_model_path, float detection_threshold,
                               const std::string& username, bool debug,
-                              ICameraCaptureSession* session) {
+                              ICameraCaptureSession* session,
+                              const IRCaptureParams& ir_params) {
   if (device_path.empty()) {
     return false;
   }
@@ -33,29 +28,77 @@ bool checkAntispoofByIRCamera(const std::string& device_path,
     return false;
   }
 
-  ImageRGB frame;
-  if (session && session->isOpen()) {
-    frame = session->capture();
-  } else {
-    frame = captureImageByIRCamera(device_path, kIrCaptureWarmupFrames, kIrCaptureTimeoutMs,
-                                   kIrCapturePollIntervalMs);
+  // If no pre-opened session, create a fresh one
+  std::unique_ptr<ICameraCaptureSession> local_session;
+  if (!session || !session->isOpen()) {
+    local_session = openCameraSession(device_path, CameraCaptureFormat::V4L2NV12,
+                                      ir_params.warmup_frames, ir_params.capture_timeout_ms,
+                                      ir_params.poll_interval_ms);
+    if (!local_session) {
+      spdlog::warn("FaceAuth: NV12 IR capture unavailable for '{}'; falling back to GREY",
+                   device_path);
+      local_session = openCameraSession(device_path, CameraCaptureFormat::V4L2Grey,
+                                        ir_params.warmup_frames, ir_params.capture_timeout_ms,
+                                        ir_params.poll_interval_ms);
+    }
+    if (!local_session) {
+      spdlog::error("FaceAuth: IR camera failed to open {}", device_path);
+      return false;
+    }
+    session = local_session.get();
   }
-  if (frame.empty()) {
-    spdlog::error("FaceAuth: IR camera failed to capture frame from {}", device_path);
-    return false;
+
+  // Camera warmup delay before first capture (AGC settling, auto-exposure, etc.)
+  if (ir_params.camera_warmup_ms > 0) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(ir_params.camera_warmup_ms));
   }
+
+  int best_face_count = 0;
 
   try {
     FaceDetection detector(detection_model_path, 640, {"face"}, detection_threshold);
-    if (detector.inference(frame).empty()) {
-      spdlog::error("FaceAuth: IR camera check failed, no face detected in captured frame");
-      if (debug) {
-        saveFailedFace(username, frame, "ir_no_face");
+
+    for (int attempt = 0; attempt < ir_params.max_attempts; ++attempt) {
+      // Between attempts, let the IR camera AGC settle
+      if (attempt > 0 && ir_params.agc_sleep_ms > 0) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(ir_params.agc_sleep_ms));
       }
-      return false;
+
+      ImageRGB frame = session->capture();
+      if (frame.empty()) {
+        spdlog::warn("FaceAuth: IR capture attempt {}/{} returned empty frame", attempt + 1,
+                     ir_params.max_attempts);
+        continue;
+      }
+
+      auto faces = detector.inference(frame);
+      int face_count = static_cast<int>(faces.size());
+      if (face_count > best_face_count) {
+        best_face_count = face_count;
+      }
+
+      if (face_count > 0) {
+        spdlog::debug("FaceAuth: IR anti-spoofing detected {} face(s) on attempt {}/{}", face_count,
+                      attempt + 1, ir_params.max_attempts);
+        return true;
+      }
+
+      spdlog::debug("FaceAuth: IR anti-spoofing no face on attempt {}/{}", attempt + 1,
+                    ir_params.max_attempts);
     }
 
-    return true;
+    // All attempts failed
+    spdlog::error("FaceAuth: IR camera check failed, no face detected in {} capture(s) (best: {} face(s))",
+                  ir_params.max_attempts, best_face_count);
+    if (debug) {
+      // Capture one more frame to save as debug (best-effort)
+      ImageRGB debug_frame = session->capture();
+      if (!debug_frame.empty()) {
+        saveFailedFace(username, debug_frame, "ir_no_face");
+      }
+    }
+    return false;
+
   } catch (const std::exception& e) {
     spdlog::error("FaceAuth: IR anti-spoofing check failed: {}", e.what());
     return false;

--- a/auth/face/antispoofing/ir_camera_as.h
+++ b/auth/face/antispoofing/ir_camera_as.h
@@ -2,12 +2,17 @@
 
 #include <string>
 
+#include "auth_config.h"
+
 namespace biopass {
 
 class ICameraCaptureSession;
 
+using IRCaptureParams = IRCaptureConfig;
+
 bool checkAntispoofByIRCamera(const std::string& ir_camera_path, const std::string& detection_model_path,
                               float detection_threshold, const std::string& username,
-                              bool debug, ICameraCaptureSession* session = nullptr);
+                              bool debug, ICameraCaptureSession* session = nullptr,
+                              const IRCaptureParams& ir_params = IRCaptureParams{});
 
 }  // namespace biopass

--- a/auth/face/common/camera_capture.cc
+++ b/auth/face/common/camera_capture.cc
@@ -177,6 +177,215 @@ class OpenPnpCameraSession : public ICameraCaptureSession {
   std::vector<uint8_t> buffer_;
 };
 
+class V4L2NV12CameraSession : public ICameraCaptureSession {
+ public:
+  V4L2NV12CameraSession(std::string device_path, const CapFormatInfo& format, int warmup_frames,
+                        int capture_timeout_ms, int poll_interval_ms)
+      : device_path_(std::move(device_path)),
+        warmup_frames_(std::max(0, warmup_frames)),
+        capture_timeout_ms_(capture_timeout_ms),
+        poll_interval_ms_(std::max(1, poll_interval_ms)) {
+    fd_ = ::open(device_path_.c_str(), O_RDWR | O_NONBLOCK);
+    if (fd_ == -1) {
+      spdlog::error("FaceAuth: Failed to open {} for V4L2 NV12 capture: {}", device_path_,
+                    std::strerror(errno));
+      return;
+    }
+
+    v4l2_format v4l2_format_info {};
+    v4l2_format_info.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+    v4l2_format_info.fmt.pix.width = format.width;
+    v4l2_format_info.fmt.pix.height = format.height;
+    v4l2_format_info.fmt.pix.pixelformat = V4L2_PIX_FMT_NV12;
+    v4l2_format_info.fmt.pix.field = V4L2_FIELD_NONE;
+    if (xioctl_retry(fd_, VIDIOC_S_FMT, &v4l2_format_info) == -1) {
+      spdlog::error("FaceAuth: VIDIOC_S_FMT (NV12) failed for {}: {}", device_path_, std::strerror(errno));
+      close();
+      return;
+    }
+
+    if (format.fps > 0) {
+      v4l2_streamparm stream_params {};
+      stream_params.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+      stream_params.parm.capture.timeperframe.numerator = 1;
+      stream_params.parm.capture.timeperframe.denominator = format.fps;
+      xioctl_retry(fd_, VIDIOC_S_PARM, &stream_params);
+    }
+
+    width_ = v4l2_format_info.fmt.pix.width;
+    height_ = v4l2_format_info.fmt.pix.height;
+
+    v4l2_requestbuffers request_buffers {};
+    request_buffers.count = 4;
+    request_buffers.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+    request_buffers.memory = V4L2_MEMORY_MMAP;
+    if (xioctl_retry(fd_, VIDIOC_REQBUFS, &request_buffers) == -1 || request_buffers.count == 0) {
+      spdlog::error("FaceAuth: VIDIOC_REQBUFS (NV12) failed for {}: {}", device_path_, std::strerror(errno));
+      close();
+      return;
+    }
+
+    buffers_.resize(request_buffers.count);
+    for (uint32_t index = 0; index < request_buffers.count; ++index) {
+      v4l2_buffer buffer {};
+      buffer.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+      buffer.memory = V4L2_MEMORY_MMAP;
+      buffer.index = index;
+      if (xioctl_retry(fd_, VIDIOC_QUERYBUF, &buffer) == -1) {
+        spdlog::error("FaceAuth: VIDIOC_QUERYBUF (NV12) failed for {}: {}", device_path_, std::strerror(errno));
+        close();
+        return;
+      }
+
+      buffers_[index].length = buffer.length;
+      buffers_[index].start = ::mmap(nullptr, buffer.length, PROT_READ | PROT_WRITE, MAP_SHARED,
+                                     fd_, buffer.m.offset);
+      if (buffers_[index].start == MAP_FAILED) {
+        spdlog::error("FaceAuth: mmap (NV12) failed for {}: {}", device_path_, std::strerror(errno));
+        close();
+        return;
+      }
+    }
+
+    for (uint32_t index = 0; index < buffers_.size(); ++index) {
+      v4l2_buffer buffer {};
+      buffer.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+      buffer.memory = V4L2_MEMORY_MMAP;
+      buffer.index = index;
+      if (xioctl_retry(fd_, VIDIOC_QBUF, &buffer) == -1) {
+        spdlog::error("FaceAuth: VIDIOC_QBUF (NV12) failed for {}: {}", device_path_, std::strerror(errno));
+        close();
+        return;
+      }
+    }
+
+    if (xioctl_retry(fd_, VIDIOC_STREAMON, &buffer_type_) == -1) {
+      spdlog::error("FaceAuth: VIDIOC_STREAMON (NV12) failed for {}: {}", device_path_, std::strerror(errno));
+      close();
+      return;
+    }
+
+    stream_started_ = true;
+  }
+
+  ~V4L2NV12CameraSession() override { close(); }
+
+  bool isOpen() const override { return fd_ >= 0 && stream_started_; }
+
+  ImageRGB capture() override {
+    if (!isOpen()) return {};
+
+    const int total_frames_needed = warmup_frames_ + 1;
+    int captured_frames = 0;
+    const bool has_timeout = capture_timeout_ms_ > 0;
+    const auto capture_deadline = std::chrono::steady_clock::now() +
+                                  std::chrono::milliseconds(std::max(0, capture_timeout_ms_));
+
+    while (captured_frames < total_frames_needed) {
+      pollfd poll_info {};
+      poll_info.fd = fd_;
+      poll_info.events = POLLIN;
+
+      int poll_timeout_ms = -1;
+      if (has_timeout) {
+        const auto now = std::chrono::steady_clock::now();
+        if (now >= capture_deadline) {
+          spdlog::error("FaceAuth: Timed out waiting for NV12 frame from {}", device_path_);
+          close();
+          return {};
+        }
+        const auto remaining_ms =
+            std::chrono::duration_cast<std::chrono::milliseconds>(capture_deadline - now).count();
+        poll_timeout_ms = std::max(1, std::min(poll_interval_ms_, static_cast<int>(remaining_ms)));
+      }
+
+      const int poll_rc = ::poll(&poll_info, 1, poll_timeout_ms);
+      if (poll_rc == -1) {
+        if (errno == EINTR) continue;
+        spdlog::error("FaceAuth: poll failed for {}: {}", device_path_, std::strerror(errno));
+        close();
+        return {};
+      }
+      if (poll_rc == 0) continue;
+
+      v4l2_buffer buffer {};
+      buffer.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+      buffer.memory = V4L2_MEMORY_MMAP;
+      if (xioctl_retry(fd_, VIDIOC_DQBUF, &buffer) == -1) {
+        if (errno == EAGAIN) continue;
+        spdlog::error("FaceAuth: VIDIOC_DQBUF (NV12) failed for {}: {}", device_path_, std::strerror(errno));
+        close();
+        return {};
+      }
+
+      const uint8_t* frame_data = static_cast<const uint8_t*>(buffers_.at(buffer.index).start);
+      ++captured_frames;
+
+      ImageRGB image;
+      if (captured_frames >= total_frames_needed) {
+        // Extract Y (luma) plane from NV12 frame as greyscale
+        image = ImageRGB(static_cast<int>(width_), static_cast<int>(height_));
+        for (uint32_t y = 0; y < height_; ++y) {
+          const uint8_t* src_row = frame_data + y * width_;
+          uint8_t* dst_row = image.ptr() + y * width_ * 3;
+          for (uint32_t x = 0; x < width_; ++x) {
+            const uint8_t value = src_row[x];
+            dst_row[x * 3 + 0] = value;
+            dst_row[x * 3 + 1] = value;
+            dst_row[x * 3 + 2] = value;
+          }
+        }
+      }
+
+      if (xioctl_retry(fd_, VIDIOC_QBUF, &buffer) == -1) {
+        spdlog::error("FaceAuth: VIDIOC_QBUF (NV12) failed for {}: {}", device_path_, std::strerror(errno));
+        close();
+        return {};
+      }
+
+      if (!image.empty()) return image;
+    }
+
+    return {};
+  }
+
+ private:
+  struct MappedBuffer {
+    void* start = MAP_FAILED;
+    size_t length = 0;
+  };
+
+  void close() {
+    if (fd_ >= 0 && stream_started_) {
+      xioctl_retry(fd_, VIDIOC_STREAMOFF, &buffer_type_);
+      stream_started_ = false;
+    }
+    for (auto& buffer : buffers_) {
+      if (buffer.start != MAP_FAILED) {
+        ::munmap(buffer.start, buffer.length);
+        buffer.start = MAP_FAILED;
+        buffer.length = 0;
+      }
+    }
+    buffers_.clear();
+    if (fd_ >= 0) {
+      ::close(fd_);
+      fd_ = -1;
+    }
+  }
+
+  std::string device_path_;
+  int fd_ = -1;
+  uint32_t width_ = 0;
+  uint32_t height_ = 0;
+  int warmup_frames_ = 0;
+  int capture_timeout_ms_ = 0;
+  int poll_interval_ms_ = 0;
+  std::vector<MappedBuffer> buffers_;
+  v4l2_buf_type buffer_type_ = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+  bool stream_started_ = false;
+};
+
 class V4L2GreyCameraSession : public ICameraCaptureSession {
  public:
   V4L2GreyCameraSession(std::string device_path, const CapFormatInfo& format, int warmup_frames,
@@ -498,6 +707,28 @@ std::unique_ptr<ICameraCaptureSession> openCameraSession(
     return nullptr;
   }
 
+  if (format == CameraCaptureFormat::V4L2NV12) {
+    if (!linux_video_device_path.has_value()) {
+      spdlog::error("FaceAuth: Direct V4L2 NV12 capture requires a /dev/video* path");
+      Cap_releaseContext(ctx);
+      return nullptr;
+    }
+
+    const auto nv12_format = find_camera_format_by_fourcc(ctx, *device_index, V4L2_PIX_FMT_NV12);
+    if (!nv12_format.has_value()) {
+      spdlog::error("FaceAuth: Camera '{}' does not expose NV12 format", *linux_video_device_path);
+      Cap_releaseContext(ctx);
+      return nullptr;
+    }
+
+    Cap_releaseContext(ctx);
+    auto session = std::make_unique<V4L2NV12CameraSession>(*linux_video_device_path, *nv12_format,
+                                                           warmup_frames, capture_timeout_ms,
+                                                           poll_interval_ms);
+    if (!session->isOpen()) return nullptr;
+    return session;
+  }
+
   if (format == CameraCaptureFormat::V4L2Grey) {
     if (!linux_video_device_path.has_value()) {
       spdlog::error("FaceAuth: Direct V4L2 GREY capture requires a /dev/video* path");
@@ -593,8 +824,15 @@ ImageRGB captureImageByIRCamera(const std::string& device_path, int warmup_frame
     return {};
   }
 
-  auto session = openCameraSession(device_path, CameraCaptureFormat::V4L2Grey, warmup_frames,
+  // Try NV12 first (preferred), fall back to GREY
+  auto session = openCameraSession(device_path, CameraCaptureFormat::V4L2NV12, warmup_frames,
                                    capture_timeout_ms, poll_interval_ms);
+  if (!session) {
+    spdlog::warn("FaceAuth: NV12 capture unavailable for '{}'; falling back to GREY", device_path);
+    session = openCameraSession(device_path, CameraCaptureFormat::V4L2Grey, warmup_frames,
+                                capture_timeout_ms, poll_interval_ms);
+  }
+
   if (!session) {
     return {};
   }

--- a/auth/face/common/camera_capture.h
+++ b/auth/face/common/camera_capture.h
@@ -11,6 +11,7 @@ namespace biopass {
 enum class CameraCaptureFormat {
   Default,
   V4L2Grey,
+  V4L2NV12,
 };
 
 class ICameraCaptureSession {

--- a/auth/face/detection/face_detection.cc
+++ b/auth/face/detection/face_detection.cc
@@ -1,8 +1,13 @@
 #include "face_detection.h"
 
 #include <algorithm>
+#include <cmath>
 
 #include "utils.h"
+
+static float sigmoid(float x) {
+  return 1.0f / (1.0f + std::exp(-x));
+}
 
 FaceDetection::FaceDetection(const std::string &ckpt, int imgsz,
                              const std::vector<std::string> &classes, const float conf,
@@ -59,28 +64,83 @@ std::vector<Detection> FaceDetection::inference(const ImageRGB &image) {
       this->session->Run(Ort::RunOptions{nullptr}, this->input_names_cstr.data(), &input_tensor, 1,
                          this->output_names_cstr.data(), this->output_names_cstr.size());
 
-  auto &out = output_tensors[0];
-  auto shape = out.GetTensorTypeAndShapeInfo().GetShape();
-  int pred_dim = static_cast<int>(shape[1]);
-  int num_preds = static_cast<int>(shape[2]);
-  const float *output_data = out.GetTensorData<float>();
+  // Decode all YOLOv8 output heads
+  const int strides[3] = {8, 16, 32};
+  std::vector<RawDet> candidates;
+  for (size_t ti = 0; ti < output_tensors.size() && ti < 3; ++ti) {
+    auto &t = output_tensors[ti];
+    auto ts = t.GetTensorTypeAndShapeInfo().GetShape();
+    if (ts.size() < 3) continue;
+    int pred_dim = static_cast<int>(ts[1]);
+    int H = static_cast<int>(ts[2]);
+    int W = static_cast<int>(ts.size() > 3 ? ts[3] : 1);
+    int num = H * W;
+    const float *tdata = t.GetTensorData<float>();
+    int stride = strides[ti];
 
-  // NMS
-  auto raw_dets = non_max_suppression(output_data, num_preds, pred_dim, this->conf, this->iou);
-  scale_boxes({input_image.height, input_image.width}, raw_dets, {image.height, image.width});
+    if (pred_dim < 65 || H == 0 || W == 0) continue;
+
+    // ONNX tensor is NCHW layout: tdata[ch * H * W + h * W + w]
+    // We access by iterating spatial positions (h, w)
+    for (int row = 0; row < H; ++row) {
+      for (int col = 0; col < W; ++col) {
+        int sp = row * W + col;  // spatial offset within a channel
+
+        // YOLOv8-pose: class score at channel 64
+        float score = sigmoid(tdata[64 * num + sp]);
+        if (score < this->conf) continue;
+
+        // DFL decode: softmax over 16 bins per coordinate
+        auto dfl = [&](int ch_base) -> float {
+          float mx = tdata[ch_base * num + sp];
+          for (int j = 1; j < 16; ++j) {
+            float v = tdata[(ch_base + j) * num + sp];
+            if (v > mx) mx = v;
+          }
+          float sum = 0.0f, result = 0.0f;
+          for (int j = 0; j < 16; ++j) {
+            float e = std::exp(tdata[(ch_base + j) * num + sp] - mx);
+            sum += e;
+            result += j * e;
+          }
+          return result / sum;
+        };
+
+        float lt = dfl(0);   // left distance from cell center
+        float tp = dfl(16);  // top distance from cell center
+        float rb = dfl(32);  // right distance from cell center
+        float bt = dfl(48);  // bottom distance from cell center
+
+        // Cell center at (col+0.5, row+0.5) in grid units
+        float cx_cell = (col + 0.5f) * stride;
+        float cy_cell = (row + 0.5f) * stride;
+
+        RawDet d;
+        d.x1 = cx_cell - lt * stride;
+        d.y1 = cy_cell - tp * stride;
+        d.x2 = cx_cell + rb * stride;
+        d.y2 = cy_cell + bt * stride;
+        d.conf = score;
+        d.cls = 0;
+        candidates.push_back(d);
+      }
+    }
+  }
+
+  // NMS on decoded boxes
+  auto keep_indices = nms_boxes(candidates, iou);
+  scale_boxes({input_image.height, input_image.width}, candidates, {image.height, image.width});
 
   // Get detection results
   std::vector<Detection> results;
-  for (auto &d : raw_dets) {
+  for (int idx : keep_indices) {
+    auto &d = candidates[idx];
     int x1 = std::max(0, (int)d.x1);
     int y1 = std::max(0, (int)d.y1);
     int x2 = std::min(image.width, (int)d.x2);
     int y2 = std::min(image.height, (int)d.y2);
 
-    // Ensure the box has positive area after clipping
-    if (x2 - x1 <= 0 || y2 - y1 <= 0) {
-      continue;
-    }
+    if (x2 - x1 <= 0 || y2 - y1 <= 0) continue;
 
     Box xyxy_box(x1, y1, x2, y2);
     ImageRGB crop_face = image.crop(x1, y1, x2, y2);

--- a/auth/face/detection/utils.cc
+++ b/auth/face/detection/utils.cc
@@ -4,7 +4,7 @@
 #include <cmath>
 #include <numeric>
 
-static std::vector<int> nms(const std::vector<RawDet>& dets, float iou_threshold) {
+std::vector<int> nms_boxes(const std::vector<RawDet>& dets, float iou_threshold) {
   if (dets.empty())
     return {};
 
@@ -83,7 +83,7 @@ std::vector<RawDet> non_max_suppression(const float* output, int num_preds, int 
     candidates.push_back(d);
   }
 
-  auto keep_indices = nms(candidates, iou_thres);
+  auto keep_indices = nms_boxes(candidates, iou_thres);
   std::vector<RawDet> result;
   for (int i = 0; i < std::min(static_cast<int>(keep_indices.size()), max_det); i++) {
     result.push_back(candidates[keep_indices[i]]);

--- a/auth/face/detection/utils.h
+++ b/auth/face/detection/utils.h
@@ -13,6 +13,8 @@ std::vector<RawDet> non_max_suppression(const float* output, int num_preds, int 
                                         float conf_thres = 0.25, float iou_thres = 0.45,
                                         int max_det = 300);
 
+std::vector<int> nms_boxes(const std::vector<RawDet>& dets, float iou_threshold);
+
 void scale_boxes(const std::vector<int>& img1_shape, std::vector<RawDet>& dets,
                  const std::vector<int>& img0_shape);
 

--- a/auth/face/face_auth.cc
+++ b/auth/face/face_auth.cc
@@ -16,26 +16,46 @@
 
 namespace biopass {
 
-namespace {
+const IRCaptureParams& FaceAuth::irParams() const {
+  return face_config_.advanced.ir_capture;
+}
 
-constexpr int kIrCaptureWarmupFrames = 5;
-constexpr int kIrCaptureTimeoutMs = 3000;
-constexpr int kIrCapturePollIntervalMs = 10;
+bool FaceAuth::isAvailable() const {
+  return checkCameraAvailability(face_config_.camera_device);
+}
 
-}  // namespace
-
-bool FaceAuth::isAvailable() const { return checkCameraAvailability(std::nullopt); }
+uint32_t FaceAuth::getMaxAuthTimeMs() const {
+  if (face_config_.advanced.auth.max_time_ms > 0) {
+    return static_cast<uint32_t>(face_config_.advanced.auth.max_time_ms);
+  }
+  // Default: retries * retry_delay with some margin for capture time
+  return face_config_.retries * face_config_.retry_delay + 5000;
+}
 
 void FaceAuth::beginAuthenticationSession() {
   if (!camera_session_) {
-    camera_session_ = openCameraSession(std::nullopt);
+    camera_session_ = openCameraSession(face_config_.camera_device);
   }
 
   if (face_config_.anti_spoofing.ir_camera.has_value() &&
       !face_config_.anti_spoofing.ir_camera->empty() && !ir_camera_session_) {
-    ir_camera_session_ =
-        openCameraSession(*face_config_.anti_spoofing.ir_camera, CameraCaptureFormat::V4L2Grey,
-                          kIrCaptureWarmupFrames, kIrCaptureTimeoutMs, kIrCapturePollIntervalMs);
+    // If camera_device and ir_camera point to the same device, reuse the primary session
+    if (face_config_.camera_device.has_value() &&
+        *face_config_.camera_device == *face_config_.anti_spoofing.ir_camera) {
+      spdlog::debug("FaceAuth: IR camera same as primary device, reusing session");
+      ir_camera_session_ = nullptr;
+    } else {
+      const auto& ir = irParams();
+      ir_camera_session_ =
+          openCameraSession(*face_config_.anti_spoofing.ir_camera, CameraCaptureFormat::V4L2NV12,
+                            ir.warmup_frames, ir.capture_timeout_ms, ir.poll_interval_ms);
+      if (!ir_camera_session_) {
+        spdlog::warn("FaceAuth: NV12 IR capture unavailable; falling back to GREY");
+        ir_camera_session_ =
+            openCameraSession(*face_config_.anti_spoofing.ir_camera, CameraCaptureFormat::V4L2Grey,
+                              ir.warmup_frames, ir.capture_timeout_ms, ir.poll_interval_ms);
+      }
+    }
   }
 }
 
@@ -47,11 +67,11 @@ void FaceAuth::endAuthenticationSession() {
 AuthResult FaceAuth::authenticate(const std::string& username, const AuthConfig& config,
                                   std::atomic<bool>* cancel_signal) {
   if (!camera_session_) {
-    camera_session_ = openCameraSession(std::nullopt);
+    camera_session_ = openCameraSession(face_config_.camera_device);
   }
   if (!camera_session_ || !camera_session_->isOpen()) {
     spdlog::error("FaceAuth: Could not open camera");
-    if (!checkCameraAvailability(std::nullopt)) {
+    if (!checkCameraAvailability(face_config_.camera_device)) {
       return AuthResult::Unavailable;
     }
     return AuthResult::Retry;
@@ -113,15 +133,37 @@ AuthResult FaceAuth::authenticate(const std::string& username, const AuthConfig&
 
   ImageRGB face = detectedImages[0].image;
 
+  // Check if IR anti-spoofing is needed
   if (face_config_.anti_spoofing.ir_camera.has_value() &&
       !face_config_.anti_spoofing.ir_camera->empty() &&
       (!ir_camera_session_ || !ir_camera_session_->isOpen())) {
-    ir_camera_session_ =
-        openCameraSession(*face_config_.anti_spoofing.ir_camera, CameraCaptureFormat::V4L2Grey,
-                          kIrCaptureWarmupFrames, kIrCaptureTimeoutMs, kIrCapturePollIntervalMs);
+    // Reuse primary session if same device, otherwise open new session
+    if (face_config_.camera_device.has_value() &&
+        *face_config_.camera_device == *face_config_.anti_spoofing.ir_camera) {
+      spdlog::debug("FaceAuth: Reusing primary camera session for IR anti-spoofing");
+      ir_camera_session_ = nullptr;
+    } else {
+      const auto& ir = irParams();
+      ir_camera_session_ =
+          openCameraSession(*face_config_.anti_spoofing.ir_camera, CameraCaptureFormat::V4L2NV12,
+                            ir.warmup_frames, ir.capture_timeout_ms, ir.poll_interval_ms);
+      if (!ir_camera_session_) {
+        ir_camera_session_ =
+            openCameraSession(*face_config_.anti_spoofing.ir_camera, CameraCaptureFormat::V4L2Grey,
+                              ir.warmup_frames, ir.capture_timeout_ms, ir.poll_interval_ms);
+      }
+    }
   }
 
-  if (!checkAntiSpoof(face_config_, username, face, config, ir_camera_session_.get())) {
+  auto* ir_session = ir_camera_session_.get();
+  FaceMethodConfig as_config = face_config_;
+  if (!ir_session && face_config_.camera_device.has_value() &&
+      *face_config_.camera_device == *face_config_.anti_spoofing.ir_camera) {
+    spdlog::debug("FaceAuth: Same device for camera and IR, reusing session and disabling AI anti-spoofing");
+    ir_session = camera_session_.get();
+    as_config.anti_spoofing.enable = false;
+  }
+  if (!checkAntiSpoof(as_config, username, face, config, ir_session)) {
     spdlog::warn("FaceAuth: Anti-spoofing failed");
     if (ir_camera_session_ && !ir_camera_session_->isOpen()) {
       ir_camera_session_.reset();

--- a/auth/face/face_auth.h
+++ b/auth/face/face_auth.h
@@ -5,6 +5,7 @@
 #include "auth_config.h"
 #include "auth_method.h"
 #include "camera_capture.h"
+#include "ir_camera_as.h"
 
 namespace biopass {
 
@@ -21,10 +22,13 @@ class FaceAuth : public IAuthMethod {
   bool isAvailable() const override;
   uint32_t getRetries() const override { return face_config_.retries; }
   uint32_t getRetryDelayMs() const override { return face_config_.retry_delay; }
+  uint32_t getMaxAuthTimeMs() const override;
   void beginAuthenticationSession() override;
   void endAuthenticationSession() override;
   AuthResult authenticate(const std::string &username, const AuthConfig &config,
                           std::atomic<bool> *cancel_signal = nullptr) override;
+
+  const IRCaptureParams& irParams() const;
 
  private:
   FaceMethodConfig face_config_;

--- a/auth/face/image_utils.h
+++ b/auth/face/image_utils.h
@@ -132,6 +132,58 @@ inline ImageRGB imageResizePad(const ImageRGB &src, int tw, int th) {
 }
 
 /**
+ * Unsharp mask sharpening.  Applies a 3-tap separable blur (kernel [1,2,1])
+ * then computes: result = input + amount * (input - blurred).
+ * Clamped to [0,255].  amount ≈ 3.0 matches x4 PIL sharpness.
+ */
+inline ImageRGB sharpenImage(const ImageRGB &src, float amount = 3.0f) {
+  if (src.empty()) return {};
+  int h = src.height, w = src.width;
+  ImageRGB tmp(w, h);
+  // Horizontal pass: blur rows
+  for (int y = 0; y < h; y++) {
+    for (int x = 1; x < w - 1; x++) {
+      for (int c = 0; c < 3; c++) {
+        int v = (int)src.at(y, x - 1, c) + 2 * (int)src.at(y, x, c) + (int)src.at(y, x + 1, c);
+        tmp.at(y, x, c) = (uint8_t)((v + 2) >> 2);  // round division by 4
+      }
+    }
+    // Left/right edges: copy from src (unblurred)
+    for (int c = 0; c < 3; c++) {
+      tmp.at(y, 0, c) = src.at(y, 0, c);
+      tmp.at(y, w - 1, c) = src.at(y, w - 1, c);
+    }
+  }
+  ImageRGB blurred(w, h);
+  // Vertical pass: blur columns
+  for (int x = 0; x < w; x++) {
+    for (int y = 1; y < h - 1; y++) {
+      for (int c = 0; c < 3; c++) {
+        int v = (int)tmp.at(y - 1, x, c) + 2 * (int)tmp.at(y, x, c) + (int)tmp.at(y + 1, x, c);
+        blurred.at(y, x, c) = (uint8_t)((v + 2) >> 2);
+      }
+    }
+    for (int c = 0; c < 3; c++) {
+      blurred.at(0, x, c) = tmp.at(0, x, c);
+      blurred.at(h - 1, x, c) = tmp.at(h - 1, x, c);
+    }
+  }
+  // Unsharp mask: out = src + amount * (src - blurred)
+  ImageRGB out(w, h);
+  for (int y = 0; y < h; y++) {
+    for (int x = 0; x < w; x++) {
+      for (int c = 0; c < 3; c++) {
+        int s = (int)src.at(y, x, c);
+        int b = (int)blurred.at(y, x, c);
+        int v = (int)(s + amount * (s - b) + 0.5f);
+        out.at(y, x, c) = (uint8_t)(v < 0 ? 0 : v > 255 ? 255 : v);
+      }
+    }
+  }
+  return out;
+}
+
+/**
  * HWC RGB uint8 -> CHW float, normalized to [0,1].
  */
 inline std::vector<float> imageToChw(const ImageRGB &img) {


### PR DESCRIPTION
This branch consolidates 14 incremental patches (0001–0014) developed and tested on CachyOS Linux (Arch-based, kernel 7.0.9, WebKitGTK 2.52.3, PipeWire 1.6.5 at the moment of this PR) with Dell Webcam WB7022. Everything works on a single commit on top of a9e140b.

## Fixes included

### Camera & Preview
- Added `custom-protocol` feature to Cargo.toml (fixes "Connection refused" on startup)
- Replaced `getUserMedia` with native ffmpeg camera capture (fixes black preview caused by PipeWire DMA_DRM ↔ NV12 negotiation failure)
- 3-speed FPS selector (3/15/30 FPS) in the camera preview bar
- `CameraPreview` thread-join fix (fixes `free(): corrupted unsorted chunks` on GUI close)
- Added `V4L2NV12CameraSession` with GREY fallback (IR cameras that only expose NV12)

### Face Detection (YOLOv8-pose)
- Correct NCHW tensor access (was using NHWC indexing)
- DFL (Distribution Focal Loss) decode for bounding box regression
- Multi-head processing (strides 8, 16, 32) instead of only the first head
- Sigmoid-threshold comparison (was comparing raw logits)

### Anti-Spoofing
- Fixed class ordering: class 1 = spoof (was checking class 0)
- Added unsharp mask sharpening before AI inference (restores texture lost to webcam compression)
- Multi-frame IR capture with AGC settling sleep
- Same-device IR reuse (avoids "Device or resource busy" when camera_device == ir_camera)

### PAM
- `[success=2 default=ignore]` for biopass in system-auth (skips pam_faillock.so authfail)

### Advanced Configuration System
- 9 new config structs (UnsharpMask, IRCapture, Capture, Detection, AntiSpoofing, Enrollment, Recognition, Auth, and the AdvancedConfig wrapper)
- YAML parsing under `methods.face.advanced`
- Rust/TypeScript types with serde + Default
- Standalone "Advanced" page, per-section and global reset buttons
- Tooltips on all field labels, consistent font sizing

### Code Quality
- Refactored: extracted `parseAdvancedConfig()` helper, split GUI into `AdvancedFaceSettings.tsx`
- Replaced per-field `#[serde(default = "...")]` + 16 `default_*` functions with struct-level `#[serde(default)]`