### PR TITLE
security: fix face recognition thresholds, anti-spoof retry bypass, and IR stability

### DIFF
--- a/auth/core/auth_config.cc
+++ b/auth/core/auth_config.cc
@@ -151,6 +151,11 @@ BiopassConfig readConfig(const std::string& username) {
           if (anti_spoofing["ir_camera"] && !anti_spoofing["ir_camera"].IsNull()) {
             config.methods.face.anti_spoofing.ir_camera = anti_spoofing["ir_camera"].as<std::string>();
           }
+
+          if (anti_spoofing["ir_warmup_delay_ms"]) {
+            config.methods.face.anti_spoofing.ir_warmup_delay_ms =
+                anti_spoofing["ir_warmup_delay_ms"].as<int>();
+          }
         }
 
         // Backward compatibility with old schema:

--- a/auth/core/auth_config.h
+++ b/auth/core/auth_config.h
@@ -46,6 +46,13 @@ struct AntiSpoofingConfig {
   AntiSpoofingModelConfig model;
   // Linux device path, e.g. "/dev/video2". nullopt means disabled.
   std::optional<std::string> ir_camera = std::nullopt;
+  // Extra delay (ms) inserted after the warmup-frame discard and before the
+  // actual IR capture. Gives IR LEDs and auto-exposure time to stabilise.
+  // Configurable via anti_spoofing.ir_warmup_delay_ms in config.yaml.
+  // NOTE: The IR check verifies that a face-shaped bounding box exists in the
+  // IR frame (presence check). It is NOT a full liveness detector. A printed
+  // photo that the YOLO model can detect in IR will still pass.
+  int ir_warmup_delay_ms = 300;
 };
 
 struct FaceMethodConfig {

--- a/auth/face/antispoofing/antispoof_check.cc
+++ b/auth/face/antispoofing/antispoof_check.cc
@@ -92,14 +92,16 @@ bool checkAntiSpoof(const FaceMethodConfig& face_config, const std::string& user
     const auto detection_threshold = face_config.detection.threshold;
     const auto username_copy = username;
     const auto debug_enabled = config.debug;
+    const auto warmup_delay_ms = face_config.anti_spoofing.ir_warmup_delay_ms;
     auto* ir_camera_session_ptr = ir_camera_session;
     tasks.push_back(make_task(
         "IR", std::async(std::launch::async,
                          [ir_camera_path, detection_model, detection_threshold, username_copy,
-                          debug_enabled, ir_camera_session_ptr]() {
+                          debug_enabled, warmup_delay_ms, ir_camera_session_ptr]() {
                            return checkAntispoofByIRCamera(ir_camera_path, detection_model,
                                                            detection_threshold, username_copy,
-                                                           debug_enabled, ir_camera_session_ptr);
+                                                           debug_enabled, ir_camera_session_ptr,
+                                                           warmup_delay_ms);
         })));
   }
 

--- a/auth/face/antispoofing/ir_camera_as.cc
+++ b/auth/face/antispoofing/ir_camera_as.cc
@@ -3,8 +3,10 @@
 #include <spdlog/spdlog.h>
 
 #include <algorithm>
+#include <chrono>
 #include <cmath>
 #include <fstream>
+#include <thread>
 
 #include "camera_capture.h"
 #include "debug_image_io.h"
@@ -21,44 +23,82 @@ constexpr int kIrCapturePollIntervalMs = 10;
 }  // namespace
 
 bool checkAntispoofByIRCamera(const std::string& device_path,
-                              const std::string& detection_model_path, float detection_threshold,
-                              const std::string& username, bool debug,
-                              ICameraCaptureSession* session) {
+                               const std::string& detection_model_path, float detection_threshold,
+                               const std::string& username, bool debug,
+                               ICameraCaptureSession* session, int warmup_delay_ms) {
+  spdlog::debug("FaceAuth: IR presence check | device='{}' detection_threshold={:.3f} warmup_delay_ms={}",
+                device_path, detection_threshold, warmup_delay_ms);
+
   if (device_path.empty()) {
+    spdlog::error("FaceAuth: IR presence check skipped — device path is empty");
     return false;
   }
 
   if (!std::ifstream(detection_model_path).good()) {
-    spdlog::error("FaceAuth: Detection model file not found: {}", detection_model_path);
+    spdlog::error("FaceAuth: IR presence check — detection model not found: {}", detection_model_path);
     return false;
+  }
+
+  // Optional extra delay after warmup frames to let IR LEDs and auto-exposure stabilise.
+  if (warmup_delay_ms > 0) {
+    spdlog::debug("FaceAuth: IR presence check — sleeping {}ms for camera stabilisation", warmup_delay_ms);
+    std::this_thread::sleep_for(std::chrono::milliseconds(warmup_delay_ms));
   }
 
   ImageRGB frame;
   if (session && session->isOpen()) {
+    spdlog::debug("FaceAuth: IR presence check — capturing from existing open session");
     frame = session->capture();
   } else {
+    spdlog::debug("FaceAuth: IR presence check — opening new session on '{}'", device_path);
     frame = captureImageByIRCamera(device_path, kIrCaptureWarmupFrames, kIrCaptureTimeoutMs,
                                    kIrCapturePollIntervalMs);
   }
+
   if (frame.empty()) {
-    spdlog::error("FaceAuth: IR camera failed to capture frame from {}", device_path);
+    spdlog::error("FaceAuth: IR presence check — frame capture failed from '{}'", device_path);
     return false;
   }
 
+  spdlog::debug("FaceAuth: IR presence check — frame captured ({}x{})", frame.width, frame.height);
+
   try {
     FaceDetection detector(detection_model_path, 640, {"face"}, detection_threshold);
-    if (detector.inference(frame).empty()) {
-      spdlog::error("FaceAuth: IR camera check failed, no face detected in captured frame");
+    std::vector<Detection> detections = detector.inference(frame);
+
+    // TODO: This is a face presence check only, NOT a real liveness detector.
+    // The YOLO model only checks for any face-shaped bounding box in the IR frame.
+    // An attacker holding a printed photo or displaying a photo on a screen will
+    // pass this check once the IR camera capture succeeds. A real anti-spoofing
+    // solution requires a specialized IR liveness model (e.g. texture analysis,
+    // depth verification, or dedicated IR liveness classification).
+    // Tracked in upcoming issue.
+    if (detections.empty()) {
+      spdlog::error(
+          "FaceAuth: IR presence check FAILED — no face bounding box detected "
+          "(threshold={:.3f}, device='{}')",
+          detection_threshold, device_path);
       if (debug) {
         saveFailedFace(username, frame, "ir_no_face");
       }
       return false;
     }
 
+    // Log every detection so the caller can see confidence vs threshold.
+    for (size_t i = 0; i < detections.size(); ++i) {
+      spdlog::debug("FaceAuth: IR presence check — detection[{}] conf={:.4f} (threshold={:.3f})",
+                    i, detections[i].conf, detection_threshold);
+    }
+
+    spdlog::debug(
+        "FaceAuth: IR presence check PASSED — {} face(s) detected, best conf={:.4f} "
+        "(NOTE: presence check only, not liveness)",
+        detections.size(), detections[0].conf);
     return true;
   } catch (const std::exception& e) {
-    spdlog::error("FaceAuth: IR anti-spoofing check failed: {}", e.what());
+    spdlog::error("FaceAuth: IR presence check — exception during detection: {}", e.what());
     return false;
   }
 }
+
 }  // namespace biopass

--- a/auth/face/antispoofing/ir_camera_as.h
+++ b/auth/face/antispoofing/ir_camera_as.h
@@ -6,8 +6,21 @@ namespace biopass {
 
 class ICameraCaptureSession;
 
-bool checkAntispoofByIRCamera(const std::string& ir_camera_path, const std::string& detection_model_path,
-                              float detection_threshold, const std::string& username,
-                              bool debug, ICameraCaptureSession* session = nullptr);
+// IR face-presence check.
+// Returns true when the YOLO face-detection model finds at least one bounding
+// box in the captured IR frame.
+//
+// IMPORTANT — this is NOT a liveness detector. It verifies that a face shape
+// is visible in the IR stream; a printed photo placed in front of an IR camera
+// can still pass this check. Treat it as a "blank-frame guard" rather than
+// anti-spoofing in the strict sense.
+//
+// warmup_delay_ms: extra sleep (ms) inserted after the V4L2 warmup frames and
+// before the capture, giving IR LEDs and auto-exposure time to stabilise.
+bool checkAntispoofByIRCamera(const std::string& ir_camera_path,
+                               const std::string& detection_model_path,
+                               float detection_threshold, const std::string& username,
+                               bool debug, ICameraCaptureSession* session = nullptr,
+                               int warmup_delay_ms = 300);
 
 }  // namespace biopass

--- a/auth/face/face_auth.cc
+++ b/auth/face/face_auth.cc
@@ -73,7 +73,11 @@ AuthResult FaceAuth::authenticate(const std::string& username, const AuthConfig&
   std::unique_ptr<FaceRecognition> faceReg;
   std::unique_ptr<FaceDetection> detector;
   try {
-    detector = std::make_unique<FaceDetection>(detectModelPath);
+    detector = std::make_unique<FaceDetection>(
+        detectModelPath, 640, std::vector<std::string>{"face"},
+        face_config_.detection.threshold);
+    spdlog::debug("FaceAuth: Detection model loaded | threshold={:.3f}",
+                  face_config_.detection.threshold);
   } catch (const std::exception& e) {
     std::string msg = e.what();
     size_t first_line = msg.find('\n');
@@ -84,7 +88,10 @@ AuthResult FaceAuth::authenticate(const std::string& username, const AuthConfig&
   }
 
   try {
-    faceReg = std::make_unique<FaceRecognition>(recogModelPath);
+    faceReg = std::make_unique<FaceRecognition>(
+        recogModelPath, 112, face_config_.recognition.threshold);
+    spdlog::debug("FaceAuth: Recognition model loaded | threshold={:.3f}",
+                  face_config_.recognition.threshold);
   } catch (const std::exception& e) {
     std::string msg = e.what();
     size_t first_line = msg.find('\n');
@@ -122,21 +129,29 @@ AuthResult FaceAuth::authenticate(const std::string& username, const AuthConfig&
   }
 
   if (!checkAntiSpoof(face_config_, username, face, config, ir_camera_session_.get())) {
-    spdlog::warn("FaceAuth: Anti-spoofing failed");
-    if (ir_camera_session_ && !ir_camera_session_->isOpen()) {
-      ir_camera_session_.reset();
-    }
-    return AuthResult::Retry;
+    spdlog::warn("FaceAuth: Anti-spoofing failed — returning Failure (no retry allowed)");
+    // Always tear down the IR session so a subsequent call cannot reuse a
+    // partially-warmed camera to bypass the check.
+    ir_camera_session_.reset();
+    return AuthResult::Failure;
   }
 
   // Match against all enrolled faces — succeed if any match.
+  spdlog::debug("FaceAuth: Recognition | threshold={:.3f} enrolled_count={}",
+                face_config_.recognition.threshold, enrolledFaces.size());
   for (const auto& facePath : enrolledFaces) {
     ImageRGB preparedFace = readImage(facePath);
-    if (preparedFace.empty())
+    if (preparedFace.empty()) {
+      spdlog::warn("FaceAuth: Recognition | could not load enrolled image: {}", facePath);
       continue;
+    }
 
     MatchResult match = faceReg->match(preparedFace, face);
+    spdlog::debug("FaceAuth: Recognition | face='{}' score={:.4f} threshold={:.3f} similar={}",
+                  facePath, match.dist, face_config_.recognition.threshold, match.similar);
     if (match.similar) {
+      spdlog::debug("FaceAuth: Recognition PASSED | matched face='{}' score={:.4f}",
+                    facePath, match.dist);
       return AuthResult::Success;
     }
   }


### PR DESCRIPTION
This PR addresses critical security vulnerabilities and reliability issues in the BioPass authentication flow:

### 1. Enforced Configured Thresholds
Previously, the configured face detection and recognition threshold values loaded from the YAML configuration were completely ignored, and the system silently fell back to the loose constructor defaults (0.50). This allowed photos, siblings, or cousins to easily pass authentication.
* Passed `face_config_.detection.threshold` into `FaceDetection`.
* Passed `face_config_.recognition.threshold` into `FaceRecognition`.
* Added high-transparency debug logs displaying the comparison score, configured threshold, similarity flag, and matched face path.

### 2. Strengthened Anti-Spoofing and Blocked Retry Exploits
Previously, when an anti-spoofing method failed (AI or IR), the authentication logic returned `AuthResult::Retry`. Since the camera session was kept open, subsequent frames could eventually bypass anti-spoof checks, or an IR failure would get masked by the retry loop.
* Modified the authentication loop to return `AuthResult::Failure` immediately when any enabled anti-spoofing check fails (AI or IR).
* Forced a complete teardown of the IR camera session upon anti-spoof failure (`ir_camera_session_.reset()`) to prevent subsequent attempts from exploiting a warmed-up camera.

### 3. Enhanced IR Camera Support and Stability
* Added an optional `anti_spoofing.ir_warmup_delay_ms` setting (defaulting to 300ms) configurable via YAML to allow IR LEDs and auto-exposure time to stabilize before capturing a frame.
* Added comprehensive logging detailing face detection confidence vs thresholds in IR frames.
* Documented clearly in code comments that the current IR check is a presence check (bounding box detection) and does not perform real texture/depth liveness analysis, noting the need for a dedicated IR liveness model.

These changes make the biometric authentication significantly more secure, robust, and transparent.
