### PR TITLE
feat(antispoof): add MiniFASv2 model

### DIFF
--- a/auth/face/antispoofing/face_as.cc
+++ b/auth/face/antispoofing/face_as.cc
@@ -1,5 +1,8 @@
 #include "face_as.h"
 
+#include <algorithm>
+#include <cmath>
+
 int argmax(const float* data, int size) {
   int max_index = 0;
   float max_val = data[0];
@@ -12,10 +15,18 @@ int argmax(const float* data, int size) {
   return max_index;
 }
 
-FaceAntiSpoofing::FaceAntiSpoofing(const std::string& ckpt, int imgsz, const float threshold) {
+FaceAntiSpoofing::FaceAntiSpoofing(const std::string& ckpt, int imgsz, const float threshold,
+                                   const std::string& model_type) {
   this->ckpt = ckpt;
   this->imgsz = imgsz;
   this->threshold = threshold;
+  this->model_type = model_type;
+
+  // Unrecognized model_type: infer from the checkpoint filename.
+  if (this->model_type != "minifasv2" && this->model_type != "mobilenetv3") {
+    this->model_type = (ckpt.find("mobilenetv3") != std::string::npos) ? "mobilenetv3" : "minifasv2";
+  }
+
   this->loadModel(ckpt);
 }
 
@@ -47,12 +58,24 @@ void FaceAntiSpoofing::loadModel(const std::string& ckpt) {
     this->output_names_cstr.push_back(s.c_str());
 }
 
-std::vector<float> FaceAntiSpoofing::preprocess(const ImageRGB& input_image) {
+std::vector<float> FaceAntiSpoofing::preprocessMobileNetV3(const ImageRGB& image) {
   const float mean[3] = {0.5931f, 0.4690f, 0.4229f};
   const float std[3] = {0.2471f, 0.2214f, 0.2157f};
-  ImageRGB resize_img = resizeImage(input_image, this->imgsz, this->imgsz);
+  ImageRGB resize_img = resizeImage(image, this->imgsz, this->imgsz);
 
   return imageToChwNormalized(resize_img, mean, std);
+}
+
+std::vector<float> FaceAntiSpoofing::preprocessMiniFASv2(const ImageRGB& image) {
+  ImageRGB letterboxed = imageLetterboxReflect101(image, this->imgsz);
+  return imageToChw(letterboxed);
+}
+
+std::vector<float> FaceAntiSpoofing::preprocess(const ImageRGB& image) {
+  if (this->model_type == "mobilenetv3") {
+    return this->preprocessMobileNetV3(image);
+  }
+  return this->preprocessMiniFASv2(image);
 }
 
 SpoofResult FaceAntiSpoofing::inference(const ImageRGB& image) {
@@ -69,7 +92,17 @@ SpoofResult FaceAntiSpoofing::inference(const ImageRGB& image) {
 
   const float* logits = output_tensors[0].GetTensorData<float>();
 
-  int spoof_cls = argmax(logits, 2);
-  float score = logits[spoof_cls];
-  return SpoofResult(score, spoof_cls == 0 && score >= this->threshold);
+  if (this->model_type == "mobilenetv3") {
+    // Index 0: Spoof, Index 1: Real
+    int spoof_cls = argmax(logits, 2);
+    float score = logits[spoof_cls];
+    return SpoofResult(score, spoof_cls == 0 && score >= this->threshold);
+  }
+
+  // minifasv2: logits[0] = real_logit, logits[1] = spoof_logit
+  float max_logit = std::max(logits[0], logits[1]);
+  float exp_real = std::exp(logits[0] - max_logit);
+  float exp_spoof = std::exp(logits[1] - max_logit);
+  float spoof_prob = exp_spoof / (exp_real + exp_spoof);
+  return SpoofResult(spoof_prob, spoof_prob >= this->threshold);
 }

--- a/auth/face/antispoofing/face_as.h
+++ b/auth/face/antispoofing/face_as.h
@@ -16,18 +16,24 @@ struct SpoofResult {
   SpoofResult(float score, bool spoof) : score(score), spoof(spoof) {}
 };
 
+// model_type: "minifasv2" or "mobilenetv3" (default)
 class FaceAntiSpoofing {
  public:
-  FaceAntiSpoofing(const std::string& ckpt, int imgsz = 128, const float threshold = 0.8);
+  FaceAntiSpoofing(const std::string& ckpt, int imgsz = 128, const float threshold = 0.8,
+                   const std::string& model_type = "mobilenetv3");
 
   void loadModel(const std::string& ckpt);
   SpoofResult inference(const ImageRGB& image);
   std::vector<float> preprocess(const ImageRGB& image);
 
  private:
+  std::vector<float> preprocessMobileNetV3(const ImageRGB& image);
+  std::vector<float> preprocessMiniFASv2(const ImageRGB& image);
+
   std::string ckpt;
   float threshold;
   int imgsz;
+  std::string model_type;
 
   Ort::Env env{ORT_LOGGING_LEVEL_WARNING, "FaceAntiSpoofing"};
   std::unique_ptr<Ort::Session> session;

--- a/auth/face/image_utils.h
+++ b/auth/face/image_utils.h
@@ -2,6 +2,7 @@
 #define IMAGE_UTILS_H
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <cstdint>
 #include <cstdio>
@@ -129,6 +130,163 @@ inline ImageRGB imageLetterbox(const ImageRGB &src, int tw, int th, uint8_t pad_
  */
 inline ImageRGB imageResizePad(const ImageRGB &src, int tw, int th) {
   return imageLetterbox(src, tw, th, 0);
+}
+
+/**
+ * Area-average resize (downscaling).
+ */
+inline ImageRGB resizeImageArea(const ImageRGB &src, int tw, int th) {
+  if (src.empty() || tw <= 0 || th <= 0) return {};
+  ImageRGB dst(tw, th);
+
+  double sx = (double)src.width / tw;
+  double sy = (double)src.height / th;
+
+  for (int y = 0; y < th; y++) {
+    double y0 = y * sy;
+    double y1 = (y + 1) * sy;
+    int iy0 = (int)std::floor(y0);
+    int iy1 = std::min(src.height, (int)std::ceil(y1));
+
+    for (int x = 0; x < tw; x++) {
+      double x0 = x * sx;
+      double x1 = (x + 1) * sx;
+      int ix0 = (int)std::floor(x0);
+      int ix1 = std::min(src.width, (int)std::ceil(x1));
+
+      double acc[3] = {0, 0, 0};
+      double weight_sum = 0;
+      for (int sy_i = iy0; sy_i < iy1; sy_i++) {
+        double wy = std::min((double)(sy_i + 1), y1) - std::max((double)sy_i, y0);
+        if (wy <= 0) continue;
+        for (int sx_i = ix0; sx_i < ix1; sx_i++) {
+          double wx = std::min((double)(sx_i + 1), x1) - std::max((double)sx_i, x0);
+          if (wx <= 0) continue;
+          double w = wx * wy;
+          for (int c = 0; c < 3; c++) acc[c] += src.at(sy_i, sx_i, c) * w;
+          weight_sum += w;
+        }
+      }
+
+      for (int c = 0; c < 3; c++) {
+        double v = (weight_sum > 0) ? acc[c] / weight_sum : 0.0;
+        dst.at(y, x, c) = (uint8_t)std::min(255.0, std::max(0.0, std::round(v)));
+      }
+    }
+  }
+  return dst;
+}
+
+namespace image_utils_detail {
+
+// 4-lobe Lanczos kernel.
+inline double lanczos4(double x) {
+  constexpr double kA = 4.0;
+  if (x == 0.0) return 1.0;
+  if (x <= -kA || x >= kA) return 0.0;
+  const double px = M_PI * x;
+  return kA * std::sin(px) * std::sin(px / kA) / (px * px);
+}
+
+// Lanczos4 sample weights/indices for one output coordinate.
+inline void lanczos4Weights(double src_pos, int src_size, int *idx, double *w) {
+  int center = (int)std::floor(src_pos);
+  for (int k = -3; k <= 4; k++) {
+    int i = center + k;
+    double dist = src_pos - i;
+    w[k + 3] = lanczos4(dist);
+    idx[k + 3] = std::min(std::max(i, 0), src_size - 1);
+  }
+}
+
+}
+
+// Lanczos4 resize (upscaling): separable 8-tap windowed-sinc resampling.
+inline ImageRGB resizeImageLanczos4(const ImageRGB &src, int tw, int th) {
+  if (src.empty() || tw <= 0 || th <= 0) return {};
+  ImageRGB dst(tw, th);
+
+  double sx = (double)src.width / tw;
+  double sy = (double)src.height / th;
+
+  // Precompute horizontal weights/indices per output column.
+  std::vector<std::array<int, 8>> col_idx(tw);
+  std::vector<std::array<double, 8>> col_w(tw);
+  for (int x = 0; x < tw; x++) {
+    double src_x = (x + 0.5) * sx - 0.5;
+    image_utils_detail::lanczos4Weights(src_x, src.width, col_idx[x].data(), col_w[x].data());
+  }
+
+  for (int y = 0; y < th; y++) {
+    double src_y = (y + 0.5) * sy - 0.5;
+    int row_idx[8];
+    double row_w[8];
+    image_utils_detail::lanczos4Weights(src_y, src.height, row_idx, row_w);
+
+    for (int x = 0; x < tw; x++) {
+      double acc[3] = {0, 0, 0};
+      for (int ky = 0; ky < 8; ky++) {
+        for (int kx = 0; kx < 8; kx++) {
+          double w = row_w[ky] * col_w[x][kx];
+          for (int c = 0; c < 3; c++)
+            acc[c] += src.at(row_idx[ky], col_idx[x][kx], c) * w;
+        }
+      }
+      for (int c = 0; c < 3; c++) {
+        dst.at(y, x, c) = (uint8_t)std::min(255.0, std::max(0.0, std::round(acc[c])));
+      }
+    }
+  }
+  return dst;
+}
+
+/**
+ * Letterbox resize to imgsz x imgsz: Lanczos4 (upscale) or Area (downscale),
+ * then pad with reflect-101.
+ */
+inline ImageRGB imageLetterboxReflect101(const ImageRGB &src, int imgsz) {
+  if (src.empty() || imgsz <= 0) return {};
+
+  int old_h = src.height;
+  int old_w = src.width;
+  double ratio = (double)imgsz / std::max(old_h, old_w);
+  int scaled_h = (int)(old_h * ratio);
+  int scaled_w = (int)(old_w * ratio);
+
+  ImageRGB resized = (ratio > 1.0) ? resizeImageLanczos4(src, scaled_w, scaled_h)
+                                    : resizeImageArea(src, scaled_w, scaled_h);
+
+  int delta_w = imgsz - scaled_w;
+  int delta_h = imgsz - scaled_h;
+  int top = delta_h / 2;
+  int left = delta_w / 2;
+
+  ImageRGB out(imgsz, imgsz);
+  for (int y = 0; y < imgsz; y++) {
+    int sy = y - top;
+    // reflect-101: mirror without repeating the edge pixel.
+    if (scaled_h > 1) {
+      while (sy < 0 || sy >= scaled_h) {
+        if (sy < 0) sy = -sy;
+        if (sy >= scaled_h) sy = 2 * (scaled_h - 1) - sy;
+      }
+    } else {
+      sy = 0;
+    }
+    for (int x = 0; x < imgsz; x++) {
+      int sx = x - left;
+      if (scaled_w > 1) {
+        while (sx < 0 || sx >= scaled_w) {
+          if (sx < 0) sx = -sx;
+          if (sx >= scaled_w) sx = 2 * (scaled_w - 1) - sx;
+        }
+      } else {
+        sx = 0;
+      }
+      for (int c = 0; c < 3; c++) out.at(y, x, c) = resized.at(sy, sx, c);
+    }
+  }
+  return out;
 }
 
 /**

--- a/auth/face/models/minifas_v2.onnx
+++ b/auth/face/models/minifas_v2.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:af2381b88f38769222ed93379e12444e2a50814575de1c46170de570c55a42b6
+size 1912594


### PR DESCRIPTION
### What's changed

- Added [MiniFASv2](https://github.com/facenox/face-antispoof-onnx) (`minifas_v2.onnx`) as a new anti-spoofing model, alongside the existing MobileNetV3 model. I tested on a small subset, MiniFASv2 **enhanced 25%** accuracy compared with MobilenetV3.  
- `FaceAntiSpoofing` constructor now takes a `model_type` parameter (`"minifasv2"` or `"mobilenetv3"`, default = `"mobilenetv3"` to preserve current behavior):
  ```cpp
  FaceAntiSpoofing(const std::string& ckpt, int imgsz = 128, const float threshold = 0.8,
                    const std::string& model_type = "mobilenetv3");
  ```
- Added model-specific preprocessing (`preprocessMobileNetV3`, `preprocessMiniFASv2`) and decision logic in `face_as.cc`:
  - **MobileNetV3** (class 0 is spoof, class 1 is real).
  - **MiniFASv2** (class 0 is real, class 1 is spoof).
  - Follow "biased toward real" rule: default is REAL, only flagged SPOOF if the score crosses `threshold`.
  - If `model_type` is unrecognized, it's inferred from the checkpoint filename (contains `"mobilenetv3"` -> mobilenetv3, else -> minifasv2).
- Ported Lanczos4/Area resize + reflect-101 padding into `image_utils.h` for MiniFASv2's letterbox preprocessing.
- Added `minifas_v2.onnx` checkpoint to `auth/face/models/`.

### How to switch model_type

Currently `model_type` is hardcoded via the constructor's default parameter (`"mobilenetv3"`). The caller (`antispoof_check.cc`) does not pass it explicitly yet.

To use MiniFASv2 for testing, pass the 4th argument explicitly:

```cpp
FaceAntiSpoofing face_as(modelPath, 128, threshold, "minifasv2");
```

### Follow-up work
This up to @phucvinh57 as I'm not familiar with the UI and flow.

1. Make `model_type` configurable instead of hardcoded (e.g. via config).
2. Add `minifas_v2.onnx` to the model download step so it's fetched like the other checkpoints.
3. Expose a model selector in the UI so users can switch between MobileNetV3 and MiniFASv2. I suggest changing the default anti-spoof model to MiniFASv2.
4. Set the threshold of anti-spoof to 0.8, and lower the threshold of detection and recognition to 0.6.
