### PR TITLE
fix(face): support IR cameras that only expose MJPG (no V4L2 GREY)

### DIFF
--- a/auth/face/common/camera_capture.cc
+++ b/auth/face/common/camera_capture.cc
@@ -506,21 +506,27 @@ std::unique_ptr<ICameraCaptureSession> openCameraSession(
     }
 
     const auto grey_format = find_camera_format_by_fourcc(ctx, *device_index, V4L2_PIX_FMT_GREY);
-    if (!grey_format.has_value()) {
-      spdlog::error("FaceAuth: Camera '{}' does not expose a GREY format for direct V4L2 capture",
-                    *linux_video_device_path);
+    if (grey_format.has_value()) {
       Cap_releaseContext(ctx);
-      return nullptr;
+      auto session = std::make_unique<V4L2GreyCameraSession>(*linux_video_device_path, *grey_format,
+                                                             warmup_frames, capture_timeout_ms,
+                                                             poll_interval_ms);
+      if (!session->isOpen()) {
+        return nullptr;
+      }
+      return session;
     }
 
-    Cap_releaseContext(ctx);
-    auto session = std::make_unique<V4L2GreyCameraSession>(*linux_video_device_path, *grey_format,
-                                                           warmup_frames, capture_timeout_ms,
-                                                           poll_interval_ms);
-    if (!session->isOpen()) {
-      return nullptr;
-    }
-    return session;
+    // No native GREY format. Some laptop IR sensors (e.g. Windows Hello cameras)
+    // expose the IR stream only as MJPG. Instead of failing, fall through to the
+    // openpnp capture path below, which decodes MJPG/YUYV to RGB. For an IR sensor
+    // the decoded frame is effectively grayscale (R=G=B) — exactly what the YOLO
+    // face-presence check consumes.
+    spdlog::warn(
+        "FaceAuth: Camera '{}' exposes no GREY format; falling back to decoded openpnp "
+        "capture (IR-as-MJPG).",
+        *linux_video_device_path);
+    // ctx intentionally kept alive; execution continues to the openpnp path below.
   }
 
   CapFormatInfo fmt {};


### PR DESCRIPTION
## Problem
On many laptops the IR / Windows-Hello sensor exposes its stream **only as MJPG**, with no raw `GREY` (Y8) V4L2 format. In that case `openCameraSession(..., CameraCaptureFormat::V4L2Grey)` fails hard:

    FaceAuth: Camera '/dev/videoN' does not expose a GREY format for direct V4L2 capture so IR anti-spoofing can never run on these devices.

## Root cause
The `V4L2Grey` branch returns `nullptr` when no `GREY` format is found, instead of using the openpnp capture path that already decodes MJPG/YUYV → RGB.

## Fix
When the device exposes no `GREY` format, fall through to the existing openpnp capture path instead of failing. For an IR sensor the decoded frame is effectively grayscale (R=G=B), exactly what the YOLO face-presence check needs. Cameras that do expose `GREY` keep the existing direct-V4L2 path unchanged — backward compatible. Single-file change.

## Testing
Dell laptop IR camera exposing `640x360 MJPG` on `/dev/video2` (no GREY format):
- before: `does not expose a GREY format` → IR check fails.
- after: `falling back to decoded openpnp capture` → `IR presence check — frame captured (640x360)` → face detected (conf ≈ 0.83) → `IR presence check PASSED`.

Recognition + IR-only anti-spoofing now works end-to-end on this hardware (atleast on my Dell Pro Max 16, under Fedora 43).