### PR TITLE
feat: migrate from `openpnp-capture` to `libcamera` for wider camera compatibility

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,7 +42,7 @@ jobs:
         if: contains(matrix.runner, 'ubuntu')
         run: |
           sudo apt update
-          sudo apt install -y librsvg2-dev libwebkit2gtk-4.1-dev build-essential curl wget file libxdo-dev libssl-dev libayatana-appindicator3-dev libpam0g-dev libcli11-dev rpm nasm
+          sudo apt install -y librsvg2-dev libwebkit2gtk-4.1-dev build-essential curl wget file libxdo-dev libssl-dev libayatana-appindicator3-dev libpam0g-dev libcli11-dev rpm pkg-config libcamera-dev libturbojpeg0-dev
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -92,3 +92,4 @@ jobs:
           files: |
             app/src-tauri/target/release/bundle/deb/*.deb
             app/src-tauri/target/release/bundle/rpm/*.rpm
+            auth/face/models/*.onnx

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,10 +25,10 @@ Biopass consists of a backend C++ authentication module and a frontend Tauri des
 
 **For the C++ Backend:**
 
-You need to install CMake, Make, PAM headers, CLI11 and nasm
+You need to install CMake, Make, PAM headers, CLI11, libcamera and libjpeg-turbo
 ```bash
 sudo apt update
-sudo apt install cmake make g++ libpam0g-dev libcli11-dev nasm
+sudo apt install cmake make g++ pkg-config libpam0g-dev libcli11-dev libcamera-dev libturbojpeg0-dev
 ```
 
 **For the Tauri Application:**
@@ -80,7 +80,7 @@ Biopass is built using modern and reliable technologies across both the backend 
 ### Backend Authentication Module (`auth/`)
 - **C++17**: High performance system-level execution.
 - **CMake**: Build system.
-- **openpnp-capture**: Camera capture (vendored via CMake FetchContent).
+- **libcamera**: Camera capture (system dependency via pkg-config).
 - **ONNX Runtime**: Running the machine learning models (YOLO for detection, EdgeFace for recognition, MobileNetV3 for anti-spoofing).
 - **Linux PAM**: Pluggable Authentication Module integration for the OS.
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    app/   → Tauri desktop application
 #
 #  Prerequisites
-#    auth : cmake, ninja/make, libpam0g-dev, libcli11-dev
+#    auth : cmake, ninja/make, libpam0g-dev, libcli11-dev, libcamera-dev, libturbojpeg0-dev
 #    app  : bun, rustup/cargo, tauri-cli v2, webkit2gtk, libssl-dev …
 # ---------------------------------------------------------------------------
 

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,9 @@ clean-auth:
 build-app: build-auth
 	@echo "==> [app] Installing JS dependencies…"
 	cd $(APP_DIR) && bun install --frozen-lockfile
+	@echo "==> [app] Pinning model downloader to release $(VERSION)…"
+	sed -i -E 's#^BASE_URL="https://github.com/TickLabVN/biopass/releases/(latest/download|download/[^"]+)"#BASE_URL="https://github.com/TickLabVN/biopass/releases/download/$(VERSION)"#' \
+	    $(APP_DIR)/src-tauri/scripts/download_models.sh
 	@echo "==> [app] Building Tauri application…"
 	cd $(APP_DIR) && bun run tauri build
 

--- a/app/src-tauri/scripts/download_models.sh
+++ b/app/src-tauri/scripts/download_models.sh
@@ -4,13 +4,17 @@
 
 set -euo pipefail
 
-BASE_URL="https://biopass.ticklab.site/models"
+# Overwritten at package/bundle time (see Makefile build-app) to pin this to
+# the exact release tag being built, so RC/beta bundles fetch their own
+# models instead of whatever the latest stable release happens to be.
+BASE_URL="https://github.com/TickLabVN/biopass/releases/latest/download"
 
 MODELS=(
     "${BASE_URL}/yolov8n-face.onnx"
     "${BASE_URL}/edgeface_s_gamma_05.onnx"
     "${BASE_URL}/edgeface_xs_gamma_06.onnx"
     "${BASE_URL}/mobilenetv3_antispoof.onnx"
+    "${BASE_URL}/minifas_v2.onnx"
 )
 
 LEGACY_MODELS=(

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -36,7 +36,12 @@
     ],
     "linux": {
       "deb": {
-        "depends": ["fprintd", "libwebkit2gtk-4.1-0"],
+        "depends": [
+          "fprintd",
+          "libwebkit2gtk-4.1-0",
+          "libturbojpeg0",
+          "libcamera0.7 | libcamera0.5 | libcamera0.3 | libcamera0.2"
+        ],
         "postInstallScript": "scripts/deb/postinst",
         "files": {
           "/usr/share/com.ticklab.biopass/download_models.sh": "scripts/download_models.sh",
@@ -46,13 +51,12 @@
           "/usr/lib/biopass/libbiopass_reg.so": "../../auth/build/face/recognition/libbiopass_reg.so",
           "/usr/lib/biopass/libbiopass_as.so": "../../auth/build/face/antispoofing/libbiopass_as.so",
           "/usr/lib/biopass/libonnxruntime.so.1": "../../auth/build/_deps/onnxruntime-src/lib/libonnxruntime.so.1.19.2",
-          "/usr/lib/biopass/libopenpnp-capture.so.0": "../../auth/build/_deps/openpnp-capture-build/libopenpnp-capture.so.0.0.28",
           "/etc/ld.so.conf.d/biopass.conf": "scripts/ldconf",
           "/usr/share/pam-configs/biopass": "scripts/pam.conf"
         }
       },
       "rpm": {
-        "depends": ["fprintd"],
+        "depends": ["fprintd", "libcamera", "turbojpeg"],
         "postInstallScript": "scripts/rpm/postinst",
         "postRemoveScript": "scripts/rpm/postrm",
         "files": {
@@ -63,7 +67,6 @@
           "/usr/lib/biopass/libbiopass_reg.so": "../../auth/build/face/recognition/libbiopass_reg.so",
           "/usr/lib/biopass/libbiopass_as.so": "../../auth/build/face/antispoofing/libbiopass_as.so",
           "/usr/lib/biopass/libonnxruntime.so.1": "../../auth/build/_deps/onnxruntime-src/lib/libonnxruntime.so.1.19.2",
-          "/usr/lib/biopass/libopenpnp-capture.so.0": "../../auth/build/_deps/openpnp-capture-build/libopenpnp-capture.so.0.0.28",
           "/etc/ld.so.conf.d/biopass.conf": "scripts/ldconf",
           "/usr/share/pam-configs/biopass": "scripts/pam.conf"
         }

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -37,6 +37,7 @@
     "linux": {
       "deb": {
         "depends": [
+          "curl",
           "fprintd",
           "libwebkit2gtk-4.1-0",
           "libturbojpeg0",
@@ -56,7 +57,7 @@
         }
       },
       "rpm": {
-        "depends": ["fprintd", "libcamera", "turbojpeg"],
+        "depends": ["curl", "fprintd", "libcamera", "turbojpeg"],
         "postInstallScript": "scripts/rpm/postinst",
         "postRemoveScript": "scripts/rpm/postrm",
         "files": {

--- a/auth/Dependencies.cmake
+++ b/auth/Dependencies.cmake
@@ -24,15 +24,10 @@ set(ONNXRUNTIME_INCLUDE_DIRS "${ONNXRUNTIME_ROOT}/include")
 set(ONNXRUNTIME_LIB_DIR "${ONNXRUNTIME_ROOT}/lib")
 find_library(ONNXRUNTIME_LIB onnxruntime PATHS ${ONNXRUNTIME_LIB_DIR} NO_DEFAULT_PATH)
 
-# openpnp-capture (replaces OpenCV for camera capture)
-set(CMAKE_POLICY_VERSION_MINIMUM 3.5 CACHE STRING "" FORCE)
-FetchContent_Declare(
-    openpnp-capture
-    GIT_REPOSITORY https://github.com/openpnp/openpnp-capture.git
-    GIT_TAG        32a9bdd3e8e3a31b12cb6573e7c6076208421651
-)
-FetchContent_MakeAvailable(openpnp-capture)
-unset(CMAKE_POLICY_VERSION_MINIMUM CACHE)
+# libcamera + libjpeg-turbo (camera capture; system packages via pkg-config)
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(LIBCAMERA REQUIRED IMPORTED_TARGET libcamera)
+pkg_check_modules(TURBOJPEG REQUIRED IMPORTED_TARGET libturbojpeg)
 
 FetchContent_Declare(
     stb

--- a/auth/core/auth_config.cc
+++ b/auth/core/auth_config.cc
@@ -130,25 +130,12 @@ BiopassConfig readConfig(const std::string& username) {
             config.methods.face.anti_spoofing.enable = anti_spoofing["enable"].as<bool>();
           }
 
-          if (anti_spoofing["model"]) {
+          if (anti_spoofing["model"] && anti_spoofing["model"].IsMap()) {
             const auto& model = anti_spoofing["model"];
-            if (model.IsMap()) {
-              if (model["path"])
-                config.methods.face.anti_spoofing.model.path = model["path"].as<std::string>();
-              if (model["threshold"])
-                config.methods.face.anti_spoofing.model.threshold = model["threshold"].as<float>();
-            } else if (model.IsScalar()) {
-              // Backward compatibility with old schema:
-              // anti_spoofing.model: "<path>"
-              config.methods.face.anti_spoofing.model.path = model.as<std::string>();
-            }
-          }
-
-          // Backward compatibility with old schema:
-          // anti_spoofing.threshold: <float>
-          if (anti_spoofing["threshold"]) {
-            config.methods.face.anti_spoofing.model.threshold =
-                anti_spoofing["threshold"].as<float>();
+            if (model["path"])
+              config.methods.face.anti_spoofing.model.path = model["path"].as<std::string>();
+            if (model["threshold"])
+              config.methods.face.anti_spoofing.model.threshold = model["threshold"].as<float>();
           }
 
           if (anti_spoofing["ir_camera"] && !anti_spoofing["ir_camera"].IsNull()) {
@@ -160,22 +147,10 @@ BiopassConfig readConfig(const std::string& username) {
             config.methods.face.anti_spoofing.ir_warmup_delay_ms =
                 anti_spoofing["ir_warmup_delay_ms"].as<int>();
           }
-        }
 
-        // Backward compatibility with old schema:
-        // methods.face.ir_camera.enable + methods.face.ir_camera.device_id
-        const bool ir_camera_missing = !config.methods.face.anti_spoofing.ir_camera.has_value() ||
-                                       config.methods.face.anti_spoofing.ir_camera->empty();
-        if (f["ir_camera"] && ir_camera_missing) {
-          bool ir_enable = false;
-          int ir_device_id = 0;
-          if (f["ir_camera"]["enable"])
-            ir_enable = f["ir_camera"]["enable"].as<bool>();
-          if (f["ir_camera"]["device_id"])
-            ir_device_id = f["ir_camera"]["device_id"].as<int>();
-          if (ir_enable) {
-            config.methods.face.anti_spoofing.ir_camera =
-                "/dev/video" + std::to_string(ir_device_id);
+          if (anti_spoofing["ir_presence_timeout_ms"]) {
+            config.methods.face.anti_spoofing.ir_presence_timeout_ms =
+                anti_spoofing["ir_presence_timeout_ms"].as<int>();
           }
         }
       }
@@ -189,8 +164,6 @@ BiopassConfig readConfig(const std::string& username) {
           config.methods.fingerprint.retries = fp["retries"].as<uint32_t>();
         if (fp["timeout"])
           config.methods.fingerprint.timeout = fp["timeout"].as<uint32_t>();
-        else if (fp["retry_delay"])
-          config.methods.fingerprint.timeout = fp["retry_delay"].as<uint32_t>();
 
         if (fp["fingers"] && fp["fingers"].IsSequence()) {
           config.methods.fingerprint.fingers.clear();
@@ -241,116 +214,6 @@ BiopassConfig readConfig(const std::string& username) {
   }
 
   return config;
-}
-
-bool migrateConfigSchema(const std::string& username, std::string* error) {
-  const std::string config_path = getConfigPath(username);
-  try {
-    YAML::Node yaml = YAML::LoadFile(config_path);
-    if (!yaml["methods"] || !yaml["methods"]["face"]) {
-      return true;
-    }
-
-    YAML::Node face = yaml["methods"]["face"];
-    YAML::Node anti = face["anti_spoofing"];
-
-    bool enable = false;
-    std::string model_path = "models/mobilenetv3_antispoof.onnx";
-    float threshold = 0.8f;
-    std::string ir_camera_path;
-
-    if (anti) {
-      if (anti["enable"]) {
-        enable = anti["enable"].as<bool>();
-      }
-
-      if (anti["model"]) {
-        YAML::Node model = anti["model"];
-        if (model.IsMap()) {
-          if (model["path"])
-            model_path = model["path"].as<std::string>();
-          if (model["threshold"])
-            threshold = model["threshold"].as<float>();
-        } else if (model.IsScalar()) {
-          model_path = model.as<std::string>();
-        }
-      }
-
-      // Old schema path.
-      if (anti["threshold"]) {
-        threshold = anti["threshold"].as<float>();
-      }
-
-      if (anti["ir_camera"] && !anti["ir_camera"].IsNull()) {
-        ir_camera_path = anti["ir_camera"].as<std::string>();
-      }
-    }
-
-    if (ir_camera_path.empty() && face["ir_camera"]) {
-      bool ir_enable = false;
-      int ir_device_id = 0;
-      if (face["ir_camera"]["enable"]) {
-        ir_enable = face["ir_camera"]["enable"].as<bool>();
-      }
-      if (face["ir_camera"]["device_id"]) {
-        ir_device_id = face["ir_camera"]["device_id"].as<int>();
-      }
-      if (ir_enable) {
-        ir_camera_path = "/dev/video" + std::to_string(ir_device_id);
-      }
-    }
-
-    // Idempotency guard:
-    // If config is already in the new schema and there are no legacy fields left,
-    // skip writing to disk.
-    const bool has_legacy_face_ir = static_cast<bool>(face["ir_camera"]);
-    const bool has_legacy_anti_threshold = anti && static_cast<bool>(anti["threshold"]);
-    const bool has_legacy_anti_model_scalar =
-        anti && static_cast<bool>(anti["model"]) && anti["model"].IsScalar();
-    const bool has_new_model_map =
-        anti && static_cast<bool>(anti["model"]) && anti["model"].IsMap() &&
-        static_cast<bool>(anti["model"]["path"]) && static_cast<bool>(anti["model"]["threshold"]);
-    const bool has_new_ir_key = anti && static_cast<bool>(anti["ir_camera"]);
-    const bool needs_migration = has_legacy_face_ir || has_legacy_anti_threshold ||
-                                 has_legacy_anti_model_scalar || !has_new_model_map ||
-                                 !has_new_ir_key;
-    if (!needs_migration)
-      return true;
-
-    YAML::Node anti_new;
-    anti_new["enable"] = enable;
-    YAML::Node model_new;
-    model_new["path"] = model_path;
-    model_new["threshold"] = threshold;
-    anti_new["model"] = model_new;
-    if (ir_camera_path.empty()) {
-      anti_new["ir_camera"] = YAML::Node();
-    } else {
-      anti_new["ir_camera"] = ir_camera_path;
-    }
-
-    face["anti_spoofing"] = anti_new;
-    if (face["ir_camera"]) {
-      face.remove("ir_camera");
-    }
-    yaml["methods"]["face"] = face;
-
-    std::ofstream out(config_path, std::ios::trunc);
-    if (!out.is_open()) {
-      if (error)
-        *error = "Failed to open config for writing: " + config_path;
-      return false;
-    }
-    out << yaml;
-    return true;
-  } catch (const YAML::BadFile&) {
-    // No config yet is valid; migration is a no-op.
-    return true;
-  } catch (const std::exception& e) {
-    if (error)
-      *error = e.what();
-    return false;
-  }
 }
 
 // ---------------------------------------------------------------------------

--- a/auth/core/auth_config.h
+++ b/auth/core/auth_config.h
@@ -53,6 +53,12 @@ struct AntiSpoofingConfig {
   // IR frame (presence check). It is NOT a full liveness detector. A printed
   // photo that the YOLO model can detect in IR will still pass.
   int ir_warmup_delay_ms = 300;
+  // Total wall-clock budget (ms) for the IR presence check to find a face
+  // across repeated capture+inference attempts. The IR emitter blinks, so a
+  // single frame may be unusable (all-white or all-dark); retrying within
+  // this budget catches a good frame. 0 disables retry (single attempt).
+  // Configurable via anti_spoofing.ir_presence_timeout_ms in config.yaml.
+  int ir_presence_timeout_ms = 1500;
 };
 
 struct FaceMethodConfig {
@@ -106,7 +112,6 @@ struct BiopassConfig {
 std::string getConfigPath(const std::string& username);
 BiopassConfig readConfig(const std::string& username);
 bool configExists(const std::string& username);
-bool migrateConfigSchema(const std::string& username, std::string* error = nullptr);
 
 std::vector<std::string> listFaces(const std::string& username);
 std::string getDebugPath(const std::string& username);

--- a/auth/face/CMakeLists.txt
+++ b/auth/face/CMakeLists.txt
@@ -12,9 +12,24 @@ target_include_directories(biopass_stb PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
+# Shared ONNX Runtime session plumbing (env/session/allocator/IO names) used
+# by the detection, recognition, and anti-spoofing inference engines.
+add_library(biopass_onnx STATIC
+    common/onnx_session.cc
+)
+set_target_properties(biopass_onnx PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_include_directories(biopass_onnx PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/common
+    ${ONNXRUNTIME_INCLUDE_DIRS}
+)
+target_link_libraries(biopass_onnx PUBLIC
+    ${ONNXRUNTIME_LIB}
+)
+
 # Shared face utilities (camera capture, debug image I/O).
 add_library(biopass_face_common STATIC
     common/camera_capture.cc
+    common/pixel_convert.cc
     common/debug_image_io.cc
 )
 set_target_properties(biopass_face_common PROPERTIES POSITION_INDEPENDENT_CODE ON)
@@ -26,7 +41,8 @@ target_include_directories(biopass_face_common PUBLIC
 target_link_libraries(biopass_face_common
     biopass_stb
     biopass_core
-    openpnp-capture
+    PkgConfig::LIBCAMERA
+    PkgConfig::TURBOJPEG
     spdlog::spdlog_header_only
 )
 

--- a/auth/face/antispoofing/CMakeLists.txt
+++ b/auth/face/antispoofing/CMakeLists.txt
@@ -17,6 +17,7 @@ target_include_directories(biopass_as PUBLIC
 target_link_libraries(biopass_as PRIVATE
     ${ONNXRUNTIME_LIB}
     biopass_stb
+    biopass_onnx
     biopass_det
     biopass_core
     biopass_face_common

--- a/auth/face/antispoofing/antispoof_check.cc
+++ b/auth/face/antispoofing/antispoof_check.cc
@@ -1,10 +1,11 @@
 #include "antispoof_check.h"
 
+#include <spdlog/spdlog.h>
+
 #include <fstream>
 #include <future>
+#include <memory>
 #include <vector>
-
-#include <spdlog/spdlog.h>
 
 #include "debug_image_io.h"
 #include "face_as.h"
@@ -56,7 +57,7 @@ bool checkAntiSpoofByAIModel(const FaceMethodConfig& faceCfg, const std::string&
 }  // namespace
 
 bool checkAntiSpoof(const FaceMethodConfig& face_config, const std::string& username,
-                    const ImageRGB& face, const AuthConfig& config,
+                    const ImageRGB& face, const AuthConfig& config, FaceDetection* shared_detector,
                     ICameraCaptureSession* ir_camera_session) {
   const bool ai_enabled = face_config.anti_spoofing.enable;
   const bool ir_enabled = face_config.anti_spoofing.ir_camera.has_value() &&
@@ -68,40 +69,36 @@ bool checkAntiSpoof(const FaceMethodConfig& face_config, const std::string& user
   }
 
   spdlog::debug("FaceAuth: Anti-spoofing started (ai_enabled={}, ir_enabled={}, ir_camera='{}')",
-                ai_enabled, ir_enabled,
-                face_config.anti_spoofing.ir_camera.value_or(""));
+                ai_enabled, ir_enabled, face_config.anti_spoofing.ir_camera.value_or(""));
 
   std::vector<AntiSpoofTask> tasks;
 
   if (ai_enabled) {
     const auto face_config_copy = face_config;
     const auto username_copy = username;
-    const auto face_copy = face;
     const auto config_copy = config;
-    tasks.push_back(make_task(
-        "AI", std::async(std::launch::async,
-                         [face_config_copy, username_copy, face_copy, config_copy]() {
-                           return checkAntiSpoofByAIModel(face_config_copy, username_copy, face_copy,
-                                                          config_copy);
-                         })));
+    auto shared_face = std::make_shared<const ImageRGB>(face);
+    tasks.push_back(make_task("AI", std::async(std::launch::async, [face_config_copy, username_copy,
+                                                                    shared_face, config_copy]() {
+                                return checkAntiSpoofByAIModel(face_config_copy, username_copy,
+                                                               *shared_face, config_copy);
+                              })));
   }
 
   if (ir_enabled) {
     const auto ir_camera_path = *face_config.anti_spoofing.ir_camera;
-    const auto detection_model = face_config.detection.model;
-    const auto detection_threshold = face_config.detection.threshold;
     const auto username_copy = username;
     const auto debug_enabled = config.debug;
     const auto warmup_delay_ms = face_config.anti_spoofing.ir_warmup_delay_ms;
+    const auto presence_timeout_ms = face_config.anti_spoofing.ir_presence_timeout_ms;
     auto* ir_camera_session_ptr = ir_camera_session;
     tasks.push_back(make_task(
-        "IR", std::async(std::launch::async,
-                         [ir_camera_path, detection_model, detection_threshold, username_copy,
-                          debug_enabled, warmup_delay_ms, ir_camera_session_ptr]() {
-                           return checkAntispoofByIRCamera(ir_camera_path, detection_model,
-                                                           detection_threshold, username_copy,
-                                                           debug_enabled, ir_camera_session_ptr,
-                                                           warmup_delay_ms);
+        "IR", std::async(std::launch::async, [ir_camera_path, shared_detector, username_copy,
+                                              debug_enabled, warmup_delay_ms, presence_timeout_ms,
+                                              ir_camera_session_ptr]() {
+          return checkAntispoofByIRCamera(ir_camera_path, shared_detector, username_copy,
+                                          debug_enabled, ir_camera_session_ptr, warmup_delay_ms,
+                                          presence_timeout_ms);
         })));
   }
 

--- a/auth/face/antispoofing/antispoof_check.h
+++ b/auth/face/antispoofing/antispoof_check.h
@@ -9,9 +9,12 @@
 namespace biopass {
 
 class ICameraCaptureSession;
+class FaceDetection;
 
+// shared_detector: the caller's already-loaded face detector, reused for the
+// IR presence check instead of loading a second copy of the model.
 bool checkAntiSpoof(const FaceMethodConfig& face_config, const std::string& username,
-                    const ImageRGB& face, const AuthConfig& config,
+                    const ImageRGB& face, const AuthConfig& config, FaceDetection* shared_detector,
                     ICameraCaptureSession* ir_camera_session = nullptr);
 
 }  // namespace biopass

--- a/auth/face/antispoofing/face_as.cc
+++ b/auth/face/antispoofing/face_as.cc
@@ -3,6 +3,10 @@
 #include <algorithm>
 #include <cmath>
 
+namespace biopass {
+
+namespace {
+
 int argmax(const float* data, int size) {
   int max_index = 0;
   float max_val = data[0];
@@ -15,47 +19,19 @@ int argmax(const float* data, int size) {
   return max_index;
 }
 
-FaceAntiSpoofing::FaceAntiSpoofing(const std::string& ckpt, int imgsz, const float threshold,
-                                   const std::string& model_type) {
-  this->ckpt = ckpt;
-  this->imgsz = imgsz;
-  this->threshold = threshold;
-  this->model_type = model_type;
+}  // namespace
 
+FaceAntiSpoofing::FaceAntiSpoofing(const std::string& ckpt, int imgsz, const float threshold,
+                                   const std::string& model_type)
+    : threshold(threshold),
+      imgsz(imgsz),
+      model_type(model_type),
+      session(ckpt, "FaceAntiSpoofing") {
   // Unrecognized model_type: infer from the checkpoint filename.
   if (this->model_type != "minifasv2" && this->model_type != "mobilenetv3") {
-    this->model_type = (ckpt.find("mobilenetv3") != std::string::npos) ? "mobilenetv3" : "minifasv2";
+    this->model_type =
+        (ckpt.find("mobilenetv3") != std::string::npos) ? "mobilenetv3" : "minifasv2";
   }
-
-  this->loadModel(ckpt);
-}
-
-void FaceAntiSpoofing::loadModel(const std::string& ckpt) {
-  this->ckpt = ckpt;
-
-  Ort::SessionOptions opts;
-  opts.SetIntraOpNumThreads(1);
-  opts.SetGraphOptimizationLevel(GraphOptimizationLevel::ORT_ENABLE_ALL);
-
-  this->session = std::make_unique<Ort::Session>(this->env, ckpt.c_str(), opts);
-
-  this->input_names_str.clear();
-  this->output_names_str.clear();
-  this->input_names_cstr.clear();
-  this->output_names_cstr.clear();
-
-  for (size_t i = 0; i < this->session->GetInputCount(); i++) {
-    auto name = this->session->GetInputNameAllocated(i, this->allocator);
-    this->input_names_str.push_back(name.get());
-  }
-  for (size_t i = 0; i < this->session->GetOutputCount(); i++) {
-    auto name = this->session->GetOutputNameAllocated(i, this->allocator);
-    this->output_names_str.push_back(name.get());
-  }
-  for (auto& s : this->input_names_str)
-    this->input_names_cstr.push_back(s.c_str());
-  for (auto& s : this->output_names_str)
-    this->output_names_cstr.push_back(s.c_str());
 }
 
 std::vector<float> FaceAntiSpoofing::preprocessMobileNetV3(const ImageRGB& image) {
@@ -82,13 +58,7 @@ SpoofResult FaceAntiSpoofing::inference(const ImageRGB& image) {
   std::vector<float> input_data = this->preprocess(image);
 
   std::vector<int64_t> input_shape = {1, 3, (int64_t)this->imgsz, (int64_t)this->imgsz};
-  auto memory_info = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
-  Ort::Value input_tensor = Ort::Value::CreateTensor<float>(
-      memory_info, input_data.data(), input_data.size(), input_shape.data(), input_shape.size());
-
-  auto output_tensors =
-      this->session->Run(Ort::RunOptions{nullptr}, this->input_names_cstr.data(), &input_tensor, 1,
-                         this->output_names_cstr.data(), this->output_names_cstr.size());
+  auto output_tensors = this->session.run(input_data, input_shape);
 
   const float* logits = output_tensors[0].GetTensorData<float>();
 
@@ -106,3 +76,5 @@ SpoofResult FaceAntiSpoofing::inference(const ImageRGB& image) {
   float spoof_prob = exp_spoof / (exp_real + exp_spoof);
   return SpoofResult(spoof_prob, spoof_prob >= this->threshold);
 }
+
+}  // namespace biopass

--- a/auth/face/antispoofing/face_as.h
+++ b/auth/face/antispoofing/face_as.h
@@ -6,9 +6,9 @@
 
 // Image utilities (replaces OpenCV)
 #include "image_utils.h"
+#include "onnx_session.h"
 
-// ONNX Runtime
-#include <onnxruntime_cxx_api.h>
+namespace biopass {
 
 struct SpoofResult {
   float score;
@@ -22,26 +22,19 @@ class FaceAntiSpoofing {
   FaceAntiSpoofing(const std::string& ckpt, int imgsz = 128, const float threshold = 0.8,
                    const std::string& model_type = "mobilenetv3");
 
-  void loadModel(const std::string& ckpt);
   SpoofResult inference(const ImageRGB& image);
-  std::vector<float> preprocess(const ImageRGB& image);
 
  private:
+  std::vector<float> preprocess(const ImageRGB& image);
   std::vector<float> preprocessMobileNetV3(const ImageRGB& image);
   std::vector<float> preprocessMiniFASv2(const ImageRGB& image);
 
-  std::string ckpt;
   float threshold;
   int imgsz;
   std::string model_type;
-
-  Ort::Env env{ORT_LOGGING_LEVEL_WARNING, "FaceAntiSpoofing"};
-  std::unique_ptr<Ort::Session> session;
-  Ort::AllocatorWithDefaultOptions allocator;
-  std::vector<std::string> input_names_str;
-  std::vector<std::string> output_names_str;
-  std::vector<const char*> input_names_cstr;
-  std::vector<const char*> output_names_cstr;
+  OnnxSession session;
 };
+
+}  // namespace biopass
 
 #endif  // FACE_AS_H

--- a/auth/face/antispoofing/ir_camera_as.cc
+++ b/auth/face/antispoofing/ir_camera_as.cc
@@ -2,10 +2,7 @@
 
 #include <spdlog/spdlog.h>
 
-#include <algorithm>
 #include <chrono>
-#include <cmath>
-#include <fstream>
 #include <thread>
 
 #include "camera_capture.h"
@@ -14,91 +11,103 @@
 
 namespace biopass {
 
-namespace {
-
-constexpr int kIrCaptureWarmupFrames = 5;
-constexpr int kIrCaptureTimeoutMs = 3000;
-constexpr int kIrCapturePollIntervalMs = 10;
-
-}  // namespace
-
-bool checkAntispoofByIRCamera(const std::string& device_path,
-                               const std::string& detection_model_path, float detection_threshold,
-                               const std::string& username, bool debug,
-                               ICameraCaptureSession* session, int warmup_delay_ms) {
-  spdlog::debug("FaceAuth: IR presence check | device='{}' detection_threshold={:.3f} warmup_delay_ms={}",
-                device_path, detection_threshold, warmup_delay_ms);
+bool checkAntispoofByIRCamera(const std::string& device_path, FaceDetection* detector,
+                              const std::string& username, bool debug,
+                              ICameraCaptureSession* session, int warmup_delay_ms,
+                              int presence_timeout_ms) {
+  spdlog::debug(
+      "FaceAuth: IR presence check | device='{}' warmup_delay_ms={} presence_timeout_ms={}",
+      device_path, warmup_delay_ms, presence_timeout_ms);
 
   if (device_path.empty()) {
     spdlog::error("FaceAuth: IR presence check skipped — device path is empty");
     return false;
   }
 
-  if (!std::ifstream(detection_model_path).good()) {
-    spdlog::error("FaceAuth: IR presence check — detection model not found: {}", detection_model_path);
-    return false;
-  }
-
   // Optional extra delay after warmup frames to let IR LEDs and auto-exposure stabilise.
   if (warmup_delay_ms > 0) {
-    spdlog::debug("FaceAuth: IR presence check — sleeping {}ms for camera stabilisation", warmup_delay_ms);
+    spdlog::debug("FaceAuth: IR presence check — sleeping {}ms for camera stabilisation",
+                  warmup_delay_ms);
     std::this_thread::sleep_for(std::chrono::milliseconds(warmup_delay_ms));
   }
 
-  ImageRGB frame;
-  if (session && session->isOpen()) {
-    spdlog::debug("FaceAuth: IR presence check — capturing from existing open session");
-    frame = session->capture();
-  } else {
-    spdlog::debug("FaceAuth: IR presence check — opening new session on '{}'", device_path);
-    frame = captureImageByIRCamera(device_path, kIrCaptureWarmupFrames, kIrCaptureTimeoutMs,
-                                   kIrCapturePollIntervalMs);
-  }
+  const auto deadline = std::chrono::steady_clock::now() +
+                        std::chrono::milliseconds(std::max(0, presence_timeout_ms));
 
-  if (frame.empty()) {
-    spdlog::error("FaceAuth: IR presence check — frame capture failed from '{}'", device_path);
-    return false;
-  }
+  ImageRGB last_frame;
+  int attempt = 0;
+  do {
+    ++attempt;
 
-  spdlog::debug("FaceAuth: IR presence check — frame captured ({}x{})", frame.width, frame.height);
+    ImageRGB frame;
+    if (session && session->isOpen()) {
+      spdlog::debug("FaceAuth: IR presence check — attempt {} capturing from existing open session",
+                    attempt);
+      frame = session->capture();
+    } else if (session) {
+      // The session was open at the start of the retry loop but a prior capture
+      // timed out and tore it down; there is nothing left to retry against.
+      spdlog::error("FaceAuth: IR presence check — session closed, aborting retries (device='{}')",
+                    device_path);
+      break;
+    } else {
+      spdlog::debug("FaceAuth: IR presence check — attempt {} opening new session on '{}'", attempt,
+                    device_path);
+      frame = captureImageByIRCamera(device_path);
+    }
 
-  try {
-    FaceDetection detector(detection_model_path, 640, {"face"}, detection_threshold);
-    std::vector<Detection> detections = detector.inference(frame);
+    if (frame.empty()) {
+      spdlog::debug("FaceAuth: IR presence check — attempt {} frame capture failed from '{}'",
+                    attempt, device_path);
+      continue;
+    }
 
-    // TODO: This is a face presence check only, NOT a real liveness detector.
-    // The YOLO model only checks for any face-shaped bounding box in the IR frame.
-    // An attacker holding a printed photo or displaying a photo on a screen will
-    // pass this check once the IR camera capture succeeds. A real anti-spoofing
-    // solution requires a specialized IR liveness model (e.g. texture analysis,
-    // depth verification, or dedicated IR liveness classification).
-    // Tracked in upcoming issue.
-    if (detections.empty()) {
-      spdlog::error(
-          "FaceAuth: IR presence check FAILED — no face bounding box detected "
-          "(threshold={:.3f}, device='{}')",
-          detection_threshold, device_path);
-      if (debug) {
-        saveFailedFace(username, frame, "ir_no_face");
+    spdlog::debug("FaceAuth: IR presence check — attempt {} frame captured ({}x{})", attempt,
+                  frame.width, frame.height);
+    last_frame = frame;
+
+    try {
+      std::vector<Detection> detections = detector->inference(frame);
+
+      // TODO: This is a face presence check only, NOT a real liveness detector.
+      // The YOLO model only checks for any face-shaped bounding box in the IR frame.
+      // An attacker holding a printed photo or displaying a photo on a screen will
+      // pass this check once the IR camera capture succeeds. A real anti-spoofing
+      // solution requires a specialized IR liveness model (e.g. texture analysis,
+      // depth verification, or dedicated IR liveness classification).
+      // Tracked in upcoming issue.
+      if (detections.empty()) {
+        spdlog::debug(
+            "FaceAuth: IR presence check — attempt {} no face bounding box detected (device='{}')",
+            attempt, device_path);
+        continue;
       }
+
+      // Log every detection so the caller can see confidence vs threshold.
+      for (size_t i = 0; i < detections.size(); ++i) {
+        spdlog::debug("FaceAuth: IR presence check — detection[{}] conf={:.4f}", i,
+                      detections[i].conf);
+      }
+
+      spdlog::debug(
+          "FaceAuth: IR presence check PASSED — attempt {}, {} face(s) detected, best conf={:.4f} "
+          "(NOTE: presence check only, not liveness)",
+          attempt, detections.size(), detections[0].conf);
+      return true;
+    } catch (const std::exception& e) {
+      spdlog::error("FaceAuth: IR presence check — exception during detection: {}", e.what());
       return false;
     }
+  } while (std::chrono::steady_clock::now() < deadline);
 
-    // Log every detection so the caller can see confidence vs threshold.
-    for (size_t i = 0; i < detections.size(); ++i) {
-      spdlog::debug("FaceAuth: IR presence check — detection[{}] conf={:.4f} (threshold={:.3f})",
-                    i, detections[i].conf, detection_threshold);
-    }
-
-    spdlog::debug(
-        "FaceAuth: IR presence check PASSED — {} face(s) detected, best conf={:.4f} "
-        "(NOTE: presence check only, not liveness)",
-        detections.size(), detections[0].conf);
-    return true;
-  } catch (const std::exception& e) {
-    spdlog::error("FaceAuth: IR presence check — exception during detection: {}", e.what());
-    return false;
+  spdlog::error(
+      "FaceAuth: IR presence check FAILED — no face bounding box detected after {} attempt(s) "
+      "(device='{}')",
+      attempt, device_path);
+  if (debug && !last_frame.empty()) {
+    saveFailedFace(username, last_frame, "ir_no_face");
   }
+  return false;
 }
 
 }  // namespace biopass

--- a/auth/face/antispoofing/ir_camera_as.h
+++ b/auth/face/antispoofing/ir_camera_as.h
@@ -5,22 +5,30 @@
 namespace biopass {
 
 class ICameraCaptureSession;
+class FaceDetection;
 
-// IR face-presence check.
-// Returns true when the YOLO face-detection model finds at least one bounding
-// box in the captured IR frame.
+// IR face-presence check. Reuses the caller's already-loaded face detector
+// (the same one used for the main visual-camera detection) rather than
+// loading a second copy of the model.
+//
+// Returns true when the detector finds at least one bounding box in the
+// captured IR frame.
 //
 // IMPORTANT — this is NOT a liveness detector. It verifies that a face shape
 // is visible in the IR stream; a printed photo placed in front of an IR camera
 // can still pass this check. Treat it as a "blank-frame guard" rather than
 // anti-spoofing in the strict sense.
 //
-// warmup_delay_ms: extra sleep (ms) inserted after the V4L2 warmup frames and
-// before the capture, giving IR LEDs and auto-exposure time to stabilise.
-bool checkAntispoofByIRCamera(const std::string& ir_camera_path,
-                               const std::string& detection_model_path,
-                               float detection_threshold, const std::string& username,
-                               bool debug, ICameraCaptureSession* session = nullptr,
-                               int warmup_delay_ms = 300);
+// warmup_delay_ms: extra sleep (ms) inserted once, before the first capture,
+// giving IR LEDs and auto-exposure time to stabilise.
+//
+// presence_timeout_ms: total wall-clock budget for retrying capture+inference
+// until a face is found. The IR emitter blinks, so a single frame may be
+// unusable (all-white or all-dark); this lets the check retry rather than
+// fail on the first bad frame. 0 disables retry (single attempt).
+bool checkAntispoofByIRCamera(const std::string& ir_camera_path, FaceDetection* detector,
+                              const std::string& username, bool debug,
+                              ICameraCaptureSession* session = nullptr, int warmup_delay_ms = 300,
+                              int presence_timeout_ms = 1500);
 
 }  // namespace biopass

--- a/auth/face/common/camera_capture.cc
+++ b/auth/face/common/camera_capture.cc
@@ -199,7 +199,10 @@ bool negotiate(libcamera::CameraConfiguration& config, CameraCaptureFormat reque
 
   std::vector<libcamera::PixelFormat> preference;
   if (requested_format == CameraCaptureFormat::V4L2Grey) {
-    preference = {libcamera::formats::R8};
+    // Prefer a true grey stream, but some laptop IR sensors (e.g. Windows
+    // Hello cameras) only expose the IR stream as YUYV/MJPEG; decode those
+    // instead of failing outright.
+    preference = {libcamera::formats::R8, libcamera::formats::YUYV, libcamera::formats::MJPEG};
   } else {
     preference = {libcamera::formats::YUYV, libcamera::formats::MJPEG, libcamera::formats::R8};
   }
@@ -227,13 +230,17 @@ bool negotiate(libcamera::CameraConfiguration& config, CameraCaptureFormat reque
     return false;
   }
 
-  if (!isSupportedPixelFormat(stream_config.pixelFormat) ||
-      (requested_format == CameraCaptureFormat::V4L2Grey &&
-       stream_config.pixelFormat != libcamera::formats::R8)) {
+  if (!isSupportedPixelFormat(stream_config.pixelFormat)) {
     spdlog::error(
         "FaceAuth: Camera '{}' adjusted configuration to unsupported format {} (available: {})",
         camera_label, stream_config.pixelFormat.toString(), listAvailableFormats(formats));
     return false;
+  }
+
+  if (requested_format == CameraCaptureFormat::V4L2Grey &&
+      stream_config.pixelFormat != libcamera::formats::R8) {
+    spdlog::warn("FaceAuth: Camera '{}' exposes no GREY format; falling back to decoded {} capture",
+                 camera_label, stream_config.pixelFormat.toString());
   }
 
   return true;

--- a/auth/face/common/camera_capture.cc
+++ b/auth/face/common/camera_capture.cc
@@ -1,26 +1,27 @@
 #include "camera_capture.h"
 
-#include <fcntl.h>
-#include <linux/videodev2.h>
-#include <openpnp-capture.h>
-#include <poll.h>
+#include <dirent.h>
+#include <libcamera/libcamera.h>
 #include <spdlog/spdlog.h>
-#include <sys/ioctl.h>
 #include <sys/mman.h>
-#include <unistd.h>
+#include <sys/stat.h>
 
 #include <algorithm>
-#include <cerrno>
 #include <chrono>
-#include <cstdio>
+#include <condition_variable>
 #include <cstring>
+#include <deque>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <sstream>
 #include <string>
 #include <thread>
 #include <utility>
 #include <vector>
+
+#include "pixel_convert.h"
 
 namespace biopass {
 
@@ -28,451 +29,508 @@ namespace {
 
 constexpr int kDefaultWarmupFrames = 5;
 constexpr int kDefaultCaptureTimeoutMs = 10000;
-constexpr int kDefaultCapturePollIntervalMs = 10;
-
-void captureLog();
-std::optional<CapDeviceID> resolveCameraDeviceIdx(
-    CapContext ctx, const std::optional<std::string>& linux_video_device_path);
 
 std::string device_label(const std::optional<std::string>& linux_video_device_path) {
   return linux_video_device_path.has_value() ? *linux_video_device_path : std::string("<default>");
 }
 
-std::vector<std::string> enumerate_linux_video_capture_paths() {
-  std::vector<std::string> paths;
-  constexpr uint32_t kMaxDevices = 64;
-
-  for (uint32_t index = 0; index < kMaxDevices; ++index) {
-    char device_path[32];
-    std::snprintf(device_path, sizeof(device_path), "/dev/video%u", index);
-
-    const int fd = ::open(device_path, O_RDWR | O_NONBLOCK);
-    if (fd == -1) {
-      continue;
+// Routes libcamera's internal logging through spdlog so it lands in the same
+// /var/log/biopass/<user>/ files the rest of the process writes to.
+class SpdlogStreambuf : public std::streambuf {
+ public:
+  int overflow(int ch) override {
+    if (ch == EOF) {
+      return ch;
     }
-
-    v4l2_capability video_cap {};
-    if (::ioctl(fd, VIDIOC_QUERYCAP, &video_cap) == 0 &&
-        (video_cap.device_caps & V4L2_CAP_VIDEO_CAPTURE) != 0) {
-      paths.emplace_back(device_path);
+    if (ch == '\n') {
+      flushLine();
+    } else {
+      line_.push_back(static_cast<char>(ch));
     }
-
-    ::close(fd);
+    return ch;
   }
 
+ private:
+  void flushLine() {
+    if (!line_.empty()) {
+      if (line_.find(" ERROR ") != std::string::npos ||
+          line_.find(" FATAL ") != std::string::npos) {
+        spdlog::error("libcamera: {}", line_);
+      } else if (line_.find(" WARN ") != std::string::npos) {
+        spdlog::warn("libcamera: {}", line_);
+      } else {
+        spdlog::info("libcamera: {}", line_);
+      }
+      line_.clear();
+    }
+  }
+
+  std::string line_;
+};
+
+// The manager (and its logging redirection) is process-wide and outlives all
+// sessions; RGB and IR capture can run concurrently against two Camera
+// objects from a single CameraManager.
+std::shared_ptr<libcamera::CameraManager> cameraManager() {
+  static std::mutex init_mutex;
+  static std::shared_ptr<libcamera::CameraManager> manager;
+
+  std::lock_guard<std::mutex> lock(init_mutex);
+  if (manager) {
+    return manager;
+  }
+
+  if (!std::getenv("LIBCAMERA_LOG_LEVELS") && !std::getenv("LIBCAMERA_LOG_FILE")) {
+    static SpdlogStreambuf log_streambuf;
+    static std::ostream log_stream(&log_streambuf);
+    libcamera::logSetStream(&log_stream);
+  }
+
+  auto candidate = std::make_shared<libcamera::CameraManager>();
+  if (candidate->start() != 0) {
+    spdlog::error("FaceAuth: Failed to start libcamera CameraManager");
+    return nullptr;
+  }
+
+  manager = std::move(candidate);
+  return manager;
+}
+
+std::shared_ptr<libcamera::Camera> findCameraByPath(libcamera::CameraManager& manager,
+                                                    const std::string& linux_video_device_path) {
+  struct stat device_info{};
+  if (stat(linux_video_device_path.c_str(), &device_info) != 0 || !S_ISCHR(device_info.st_mode)) {
+    return nullptr;
+  }
+
+  for (const auto& camera : manager.cameras()) {
+    const auto devices = camera->properties().get(libcamera::properties::SystemDevices);
+    if (!devices) {
+      continue;
+    }
+    for (const int64_t device : *devices) {
+      if (device == static_cast<int64_t>(device_info.st_rdev)) {
+        return camera;
+      }
+    }
+  }
+  return nullptr;
+}
+
+std::shared_ptr<libcamera::Camera> findCamera(
+    libcamera::CameraManager& manager, const std::optional<std::string>& linux_video_device_path) {
+  if (linux_video_device_path.has_value()) {
+    auto camera = findCameraByPath(manager, *linux_video_device_path);
+    if (!camera) {
+      spdlog::error("FaceAuth: Camera path '{}' was not found among libcamera devices",
+                    *linux_video_device_path);
+    }
+    return camera;
+  }
+
+  const auto cameras = manager.cameras();
+  if (cameras.empty()) {
+    spdlog::error("FaceAuth: No camera devices reported by libcamera");
+    return nullptr;
+  }
+  return cameras.front();
+}
+
+// Reverse-maps a libcamera Camera's SystemDevices dev_t entries back to
+// /dev/video* node paths, for field-debugging output (listCameraDevices).
+std::vector<std::string> videoPathsForCamera(const libcamera::Camera& camera) {
+  std::vector<std::string> paths;
+  const auto devices = camera.properties().get(libcamera::properties::SystemDevices);
+  if (!devices) {
+    return paths;
+  }
+
+  DIR* dir = opendir("/dev");
+  if (!dir) {
+    return paths;
+  }
+  struct dirent* entry;
+  while ((entry = readdir(dir)) != nullptr) {
+    const std::string name(entry->d_name);
+    if (name.rfind("video", 0) != 0) {
+      continue;
+    }
+    const std::string path = "/dev/" + name;
+    struct stat st{};
+    if (stat(path.c_str(), &st) != 0 || !S_ISCHR(st.st_mode)) {
+      continue;
+    }
+    for (const int64_t device : *devices) {
+      if (device == static_cast<int64_t>(st.st_rdev)) {
+        paths.push_back(path);
+        break;
+      }
+    }
+  }
+  closedir(dir);
+  std::sort(paths.begin(), paths.end());
   return paths;
 }
 
-std::optional<std::string> linux_device_path_from_index(CapDeviceID device_index) {
-  const auto paths = enumerate_linux_video_capture_paths();
-  if (device_index >= paths.size()) {
-    return std::nullopt;
-  }
-  return paths[device_index];
+bool isSupportedPixelFormat(const libcamera::PixelFormat& format) {
+  return format == libcamera::formats::YUYV || format == libcamera::formats::MJPEG ||
+         format == libcamera::formats::R8;
 }
 
-int xioctl_retry(int fd, unsigned long request, void* arg) {
-  int rc = 0;
-  do {
-    rc = ::ioctl(fd, request, arg);
-  } while (rc == -1 && errno == EINTR);
-  return rc;
+std::string listAvailableFormats(const libcamera::StreamFormats& formats) {
+  std::ostringstream oss;
+  bool first = true;
+  for (const auto& format : formats.pixelformats()) {
+    if (!first) {
+      oss << ", ";
+    }
+    oss << format.toString();
+    first = false;
+  }
+  return oss.str();
 }
 
-std::optional<CapFormatInfo> find_camera_format_by_fourcc(CapContext ctx, CapDeviceID device_index,
-                                                           uint32_t fourcc) {
-  const int32_t format_count = Cap_getNumFormats(ctx, device_index);
-  if (format_count <= 0) {
-    return std::nullopt;
+// Picks a pixel format for the given capture request out of what the camera
+// actually offers, in preference order, then validates the configuration.
+bool negotiate(libcamera::CameraConfiguration& config, CameraCaptureFormat requested_format,
+               const std::string& camera_label) {
+  libcamera::StreamConfiguration& stream_config = config.at(0);
+  const auto& formats = stream_config.formats();
+
+  std::vector<libcamera::PixelFormat> preference;
+  if (requested_format == CameraCaptureFormat::V4L2Grey) {
+    preference = {libcamera::formats::R8};
+  } else {
+    preference = {libcamera::formats::YUYV, libcamera::formats::MJPEG, libcamera::formats::R8};
   }
 
-  for (int32_t format_index = 0; format_index < format_count; ++format_index) {
-    CapFormatInfo format {};
-    if (Cap_getFormatInfo(ctx, device_index, static_cast<CapFormatID>(format_index), &format) !=
-        CAPRESULT_OK) {
-      continue;
-    }
-    if (format.fourcc == fourcc) {
-      return format;
+  const auto available = formats.pixelformats();
+  bool picked = false;
+  for (const auto& candidate : preference) {
+    if (std::find(available.begin(), available.end(), candidate) != available.end()) {
+      stream_config.pixelFormat = candidate;
+      picked = true;
+      break;
     }
   }
 
-  return std::nullopt;
+  if (!picked) {
+    spdlog::error(
+        "FaceAuth: Camera '{}' exposes none of the required pixel formats (available: {})",
+        camera_label, listAvailableFormats(formats));
+    return false;
+  }
+
+  const auto validation = config.validate();
+  if (validation == libcamera::CameraConfiguration::Invalid) {
+    spdlog::error("FaceAuth: Invalid camera configuration for '{}'", camera_label);
+    return false;
+  }
+
+  if (!isSupportedPixelFormat(stream_config.pixelFormat) ||
+      (requested_format == CameraCaptureFormat::V4L2Grey &&
+       stream_config.pixelFormat != libcamera::formats::R8)) {
+    spdlog::error(
+        "FaceAuth: Camera '{}' adjusted configuration to unsupported format {} (available: {})",
+        camera_label, stream_config.pixelFormat.toString(), listAvailableFormats(formats));
+    return false;
+  }
+
+  return true;
 }
 
-bool capture_frame_openpnp(CapContext ctx, CapStream stream, uint8_t* buffer, size_t buffer_size,
-                           int capture_timeout_ms, int poll_interval_ms) {
-  const auto capture_deadline = std::chrono::steady_clock::now() +
-                                std::chrono::milliseconds(std::max(0, capture_timeout_ms));
-  const bool has_timeout = capture_timeout_ms > 0;
-  const auto sleep_interval = std::chrono::milliseconds(std::max(1, poll_interval_ms));
+// Converts one captured plane's bytes into RGB according to the negotiated
+// pixel format.
+bool convertFrame(const libcamera::PixelFormat& pixel_format, const uint8_t* data,
+                  size_t bytes_used, int width, int height, int stride, ImageRGB& out) {
+  if (pixel_format == libcamera::formats::YUYV) {
+    return yuyvToRgb(data, bytes_used, width, height, stride, out);
+  }
+  if (pixel_format == libcamera::formats::R8) {
+    return greyToRgb(data, bytes_used, width, height, stride, out);
+  }
+  if (pixel_format == libcamera::formats::MJPEG) {
+    return mjpegToRgb(data, bytes_used, out);
+  }
+  return false;
+}
 
-  while (!has_timeout || std::chrono::steady_clock::now() < capture_deadline) {
-    if (!Cap_hasNewFrame(ctx, stream)) {
-      std::this_thread::sleep_for(sleep_interval);
-      continue;
+class LibcameraCaptureSession : public ICameraCaptureSession {
+ public:
+  static std::unique_ptr<LibcameraCaptureSession> open(
+      std::shared_ptr<libcamera::CameraManager> manager, std::shared_ptr<libcamera::Camera> camera,
+      CameraCaptureFormat requested_format, std::string camera_label, int warmup_frames,
+      int capture_timeout_ms) {
+    auto session = std::unique_ptr<LibcameraCaptureSession>(
+        new LibcameraCaptureSession(std::move(manager), std::move(camera), requested_format,
+                                    std::move(camera_label), warmup_frames, capture_timeout_ms));
+    if (!session->setup()) {
+      return nullptr;
+    }
+    return session;
+  }
+
+  ~LibcameraCaptureSession() override { close(); }
+
+  bool isOpen() const override { return started_; }
+
+  ImageRGB capture() override {
+    if (!isOpen()) {
+      return {};
     }
 
-    if (Cap_captureFrame(ctx, stream, buffer, buffer_size) != CAPRESULT_OK) {
-      continue;
+    const bool has_timeout = capture_timeout_ms_ > 0;
+    const auto deadline = std::chrono::steady_clock::now() +
+                          std::chrono::milliseconds(std::max(0, capture_timeout_ms_));
+
+    // Drop any frames that completed before this call so a long-idle session
+    // never returns a stale frame.
+    drainPending();
+
+    // Color sessions warm up once per session (mirrors the always-running
+    // openpnp stream); grey/IR sessions warm up on every capture to let the
+    // IR emitter/AE settle (mirrors the old V4L2 GREY fallback).
+    const int discard_count = (is_grey_ || !warmed_up_) ? warmup_frames_ : 0;
+    warmed_up_ = true;
+    for (int i = 0; i < discard_count; ++i) {
+      libcamera::Request* request = waitForRequest(deadline, has_timeout);
+      if (!request) {
+        return {};
+      }
+      requeue(request);
+    }
+
+    libcamera::Request* request = waitForRequest(deadline, has_timeout);
+    if (!request) {
+      return {};
+    }
+
+    ImageRGB image;
+    const bool ok = extractFrame(request, image);
+    requeue(request);
+    if (!ok) {
+      spdlog::error("FaceAuth: Failed to convert frame from '{}'", camera_label_);
+      return {};
+    }
+    return image;
+  }
+
+ private:
+  LibcameraCaptureSession(std::shared_ptr<libcamera::CameraManager> manager,
+                          std::shared_ptr<libcamera::Camera> camera,
+                          CameraCaptureFormat requested_format, std::string camera_label,
+                          int warmup_frames, int capture_timeout_ms)
+      : manager_(std::move(manager)),
+        camera_(std::move(camera)),
+        camera_label_(std::move(camera_label)),
+        is_grey_(requested_format == CameraCaptureFormat::V4L2Grey),
+        warmup_frames_(std::max(0, warmup_frames)),
+        capture_timeout_ms_(capture_timeout_ms) {}
+
+  bool setup() {
+    config_ = camera_->generateConfiguration({libcamera::StreamRole::StillCapture});
+    if (!config_ || config_->size() == 0) {
+      spdlog::error("FaceAuth: Failed to generate camera configuration for '{}'", camera_label_);
+      return false;
+    }
+
+    if (!negotiate(*config_,
+                   is_grey_ ? CameraCaptureFormat::V4L2Grey : CameraCaptureFormat::Default,
+                   camera_label_)) {
+      return false;
+    }
+
+    if (camera_->acquire() != 0) {
+      spdlog::error("FaceAuth: Failed to acquire camera '{}'", camera_label_);
+      return false;
+    }
+    acquired_ = true;
+
+    if (camera_->configure(config_.get()) != 0) {
+      spdlog::error("FaceAuth: Failed to configure camera '{}'", camera_label_);
+      return false;
+    }
+
+    libcamera::StreamConfiguration& stream_config = config_->at(0);
+    pixel_format_ = stream_config.pixelFormat;
+    width_ = static_cast<int>(stream_config.size.width);
+    height_ = static_cast<int>(stream_config.size.height);
+    stride_ = static_cast<int>(stream_config.stride);
+    stream_ = stream_config.stream();
+
+    allocator_ = std::make_unique<libcamera::FrameBufferAllocator>(camera_);
+    if (allocator_->allocate(stream_) < 0) {
+      spdlog::error("FaceAuth: Failed to allocate buffers for '{}'", camera_label_);
+      return false;
+    }
+
+    for (const auto& buffer : allocator_->buffers(stream_)) {
+      auto request = camera_->createRequest();
+      if (!request || request->addBuffer(stream_, buffer.get()) < 0) {
+        spdlog::error("FaceAuth: Failed to create capture request for '{}'", camera_label_);
+        return false;
+      }
+      if (!mapBuffer(buffer.get())) {
+        spdlog::error("FaceAuth: Failed to mmap buffer for '{}'", camera_label_);
+        return false;
+      }
+      requests_.push_back(std::move(request));
+    }
+
+    camera_->requestCompleted.connect(&connection_token_, [this](libcamera::Request* request) {
+      if (request->status() == libcamera::Request::RequestCancelled) {
+        return;
+      }
+      {
+        std::lock_guard<std::mutex> lock(mutex_);
+        completed_.push_back(request);
+      }
+      ready_.notify_one();
+    });
+
+    if (camera_->start() < 0) {
+      spdlog::error("FaceAuth: Failed to start camera '{}'", camera_label_);
+      camera_->requestCompleted.disconnect(&connection_token_);
+      return false;
+    }
+    started_ = true;
+
+    for (auto& request : requests_) {
+      if (camera_->queueRequest(request.get()) < 0) {
+        spdlog::error("FaceAuth: Failed to queue initial request for '{}'", camera_label_);
+        started_ = false;
+        return false;
+      }
     }
 
     return true;
   }
 
-  return false;
-}
-
-class OpenPnpCameraSession : public ICameraCaptureSession {
- public:
-  OpenPnpCameraSession(CapContext ctx, CapStream stream, uint32_t width, uint32_t height,
-                       std::string camera_label, int capture_timeout_ms, int poll_interval_ms)
-      : ctx_(ctx),
-        stream_(stream),
-        width_(width),
-        height_(height),
-        camera_label_(std::move(camera_label)),
-        capture_timeout_ms_(capture_timeout_ms),
-        poll_interval_ms_(poll_interval_ms),
-        buffer_(static_cast<size_t>(width) * static_cast<size_t>(height) * 3) {}
-
-  ~OpenPnpCameraSession() override { close(); }
-
-  bool isOpen() const override { return ctx_ != nullptr && stream_ >= 0; }
-
-  ImageRGB capture() override {
-    if (!isOpen()) {
-      return {};
+  bool mapBuffer(libcamera::FrameBuffer* buffer) {
+    const auto planes = buffer->planes();
+    if (planes.empty()) {
+      return false;
     }
-
-    if (!capture_frame_openpnp(ctx_, stream_, buffer_.data(), buffer_.size(), capture_timeout_ms_,
-                               poll_interval_ms_)) {
-      spdlog::error("FaceAuth: Failed to capture frame from '{}'", camera_label_);
-      close();
-      return {};
+    const auto& plane = planes[0];
+    const size_t mapping_size = plane.offset + plane.length;
+    void* mapping = mmap(nullptr, mapping_size, PROT_READ, MAP_SHARED, plane.fd.get(), 0);
+    if (mapping == MAP_FAILED) {
+      return false;
     }
-
-    return ImageRGB(static_cast<int>(width_), static_cast<int>(height_), buffer_.data());
+    mappings_[buffer] = Mapping{mapping, mapping_size, plane.offset};
+    return true;
   }
 
- private:
+  // Blocks until a completed request is available or the deadline passes.
+  libcamera::Request* waitForRequest(std::chrono::steady_clock::time_point deadline,
+                                     bool has_timeout) {
+    std::unique_lock<std::mutex> lock(mutex_);
+    bool have_request;
+    if (has_timeout) {
+      have_request = ready_.wait_until(lock, deadline, [this] { return !completed_.empty(); });
+    } else {
+      ready_.wait(lock, [this] { return !completed_.empty(); });
+      have_request = true;
+    }
+    if (!have_request) {
+      spdlog::error("FaceAuth: Timed out waiting for frame from '{}'", camera_label_);
+      lock.unlock();
+      close();
+      return nullptr;
+    }
+    libcamera::Request* request = completed_.front();
+    completed_.pop_front();
+    return request;
+  }
+
+  void drainPending() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    while (!completed_.empty()) {
+      libcamera::Request* request = completed_.front();
+      completed_.pop_front();
+      request->reuse(libcamera::Request::ReuseBuffers);
+      camera_->queueRequest(request);
+    }
+  }
+
+  void requeue(libcamera::Request* request) {
+    request->reuse(libcamera::Request::ReuseBuffers);
+    camera_->queueRequest(request);
+  }
+
+  bool extractFrame(libcamera::Request* request, ImageRGB& out) {
+    libcamera::FrameBuffer* buffer = request->findBuffer(stream_);
+    if (!buffer) {
+      return false;
+    }
+    const auto it = mappings_.find(buffer);
+    if (it == mappings_.end()) {
+      return false;
+    }
+    const auto metadata = buffer->metadata().planes();
+    if (metadata.empty()) {
+      return false;
+    }
+    const size_t bytes_used = metadata[0].bytesused;
+    const uint8_t* data = static_cast<const uint8_t*>(it->second.base) + it->second.plane_offset;
+    return convertFrame(pixel_format_, data, bytes_used, width_, height_, stride_, out);
+  }
+
   void close() {
-    if (ctx_ && stream_ >= 0) {
-      Cap_closeStream(ctx_, stream_);
-      stream_ = -1;
+    if (started_) {
+      camera_->stop();
+      started_ = false;
     }
-    if (ctx_) {
-      Cap_releaseContext(ctx_);
-      ctx_ = nullptr;
+    camera_->requestCompleted.disconnect(&connection_token_);
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      completed_.clear();
+    }
+    for (auto& [buffer, mapping] : mappings_) {
+      munmap(mapping.base, mapping.size);
+    }
+    mappings_.clear();
+    requests_.clear();
+    allocator_.reset();
+    if (acquired_) {
+      camera_->release();
+      acquired_ = false;
     }
   }
 
-  CapContext ctx_ = nullptr;
-  CapStream stream_ = -1;
-  uint32_t width_ = 0;
-  uint32_t height_ = 0;
-  std::string camera_label_;
-  int capture_timeout_ms_ = 0;
-  int poll_interval_ms_ = 0;
-  std::vector<uint8_t> buffer_;
-};
-
-class V4L2GreyCameraSession : public ICameraCaptureSession {
- public:
-  V4L2GreyCameraSession(std::string device_path, const CapFormatInfo& format, int warmup_frames,
-                        int capture_timeout_ms, int poll_interval_ms)
-      : device_path_(std::move(device_path)),
-        warmup_frames_(std::max(0, warmup_frames)),
-        capture_timeout_ms_(capture_timeout_ms),
-        poll_interval_ms_(std::max(1, poll_interval_ms)) {
-    if (format.fourcc != V4L2_PIX_FMT_GREY) {
-      spdlog::error("FaceAuth: V4L2 GREY session requires GREY camera format");
-      return;
-    }
-
-    fd_ = ::open(device_path_.c_str(), O_RDWR | O_NONBLOCK);
-    if (fd_ == -1) {
-      spdlog::error("FaceAuth: Failed to open {} for V4L2 fallback: {}", device_path_,
-                    std::strerror(errno));
-      return;
-    }
-
-    v4l2_format v4l2_format_info {};
-    v4l2_format_info.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
-    v4l2_format_info.fmt.pix.width = format.width;
-    v4l2_format_info.fmt.pix.height = format.height;
-    v4l2_format_info.fmt.pix.pixelformat = format.fourcc;
-    v4l2_format_info.fmt.pix.field = V4L2_FIELD_NONE;
-    if (xioctl_retry(fd_, VIDIOC_S_FMT, &v4l2_format_info) == -1) {
-      spdlog::error("FaceAuth: VIDIOC_S_FMT failed for {}: {}", device_path_, std::strerror(errno));
-      close();
-      return;
-    }
-
-    if (format.fps > 0) {
-      v4l2_streamparm stream_params {};
-      stream_params.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
-      stream_params.parm.capture.timeperframe.numerator = 1;
-      stream_params.parm.capture.timeperframe.denominator = format.fps;
-      xioctl_retry(fd_, VIDIOC_S_PARM, &stream_params);
-    }
-
-    width_ = v4l2_format_info.fmt.pix.width;
-    height_ = v4l2_format_info.fmt.pix.height;
-    bytes_per_line_ =
-        std::max<uint32_t>(v4l2_format_info.fmt.pix.bytesperline, v4l2_format_info.fmt.pix.width);
-
-    v4l2_requestbuffers request_buffers {};
-    request_buffers.count = 4;
-    request_buffers.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
-    request_buffers.memory = V4L2_MEMORY_MMAP;
-    if (xioctl_retry(fd_, VIDIOC_REQBUFS, &request_buffers) == -1 || request_buffers.count == 0) {
-      spdlog::error("FaceAuth: VIDIOC_REQBUFS failed for {}: {}", device_path_, std::strerror(errno));
-      close();
-      return;
-    }
-
-    buffers_.resize(request_buffers.count);
-    for (uint32_t index = 0; index < request_buffers.count; ++index) {
-      v4l2_buffer buffer {};
-      buffer.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
-      buffer.memory = V4L2_MEMORY_MMAP;
-      buffer.index = index;
-      if (xioctl_retry(fd_, VIDIOC_QUERYBUF, &buffer) == -1) {
-        spdlog::error("FaceAuth: VIDIOC_QUERYBUF failed for {}: {}", device_path_,
-                      std::strerror(errno));
-        close();
-        return;
-      }
-
-      buffers_[index].length = buffer.length;
-      buffers_[index].start = ::mmap(nullptr, buffer.length, PROT_READ | PROT_WRITE, MAP_SHARED,
-                                     fd_, buffer.m.offset);
-      if (buffers_[index].start == MAP_FAILED) {
-        spdlog::error("FaceAuth: mmap failed for {}: {}", device_path_, std::strerror(errno));
-        close();
-        return;
-      }
-    }
-
-    for (uint32_t index = 0; index < buffers_.size(); ++index) {
-      v4l2_buffer buffer {};
-      buffer.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
-      buffer.memory = V4L2_MEMORY_MMAP;
-      buffer.index = index;
-      if (xioctl_retry(fd_, VIDIOC_QBUF, &buffer) == -1) {
-        spdlog::error("FaceAuth: VIDIOC_QBUF failed for {}: {}", device_path_, std::strerror(errno));
-        close();
-        return;
-      }
-    }
-
-    if (xioctl_retry(fd_, VIDIOC_STREAMON, &buffer_type_) == -1) {
-      spdlog::error("FaceAuth: VIDIOC_STREAMON failed for {}: {}", device_path_,
-                    std::strerror(errno));
-      close();
-      return;
-    }
-
-    stream_started_ = true;
-  }
-
-  ~V4L2GreyCameraSession() override { close(); }
-
-  bool isOpen() const override { return fd_ >= 0 && stream_started_; }
-
-  ImageRGB capture() override {
-    if (!isOpen()) {
-      return {};
-    }
-
-    const int total_frames_needed = warmup_frames_ + 1;
-    int captured_frames = 0;
-    const bool has_timeout = capture_timeout_ms_ > 0;
-    const auto capture_deadline = std::chrono::steady_clock::now() +
-                                  std::chrono::milliseconds(std::max(0, capture_timeout_ms_));
-
-    while (captured_frames < total_frames_needed) {
-      pollfd poll_info {};
-      poll_info.fd = fd_;
-      poll_info.events = POLLIN;
-
-      int poll_timeout_ms = -1;
-      if (has_timeout) {
-        const auto now = std::chrono::steady_clock::now();
-        if (now >= capture_deadline) {
-          spdlog::error("FaceAuth: Timed out waiting for V4L2 GREY frame from {}", device_path_);
-          close();
-          return {};
-        }
-
-        const auto remaining_ms =
-            std::chrono::duration_cast<std::chrono::milliseconds>(capture_deadline - now).count();
-        poll_timeout_ms =
-            std::max(1, std::min(poll_interval_ms_, static_cast<int>(remaining_ms)));
-      }
-
-      const int poll_rc = ::poll(&poll_info, 1, poll_timeout_ms);
-      if (poll_rc == -1) {
-        if (errno == EINTR) {
-          continue;
-        }
-        spdlog::error("FaceAuth: poll failed for {}: {}", device_path_, std::strerror(errno));
-        close();
-        return {};
-      }
-      if (poll_rc == 0) {
-        continue;
-      }
-
-      v4l2_buffer buffer {};
-      buffer.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
-      buffer.memory = V4L2_MEMORY_MMAP;
-      if (xioctl_retry(fd_, VIDIOC_DQBUF, &buffer) == -1) {
-        if (errno == EAGAIN) {
-          continue;
-        }
-        spdlog::error("FaceAuth: VIDIOC_DQBUF failed for {}: {}", device_path_,
-                      std::strerror(errno));
-        close();
-        return {};
-      }
-
-      const uint8_t* grey = static_cast<const uint8_t*>(buffers_.at(buffer.index).start);
-      ++captured_frames;
-
-      ImageRGB image;
-      if (captured_frames >= total_frames_needed) {
-        image = ImageRGB(static_cast<int>(width_), static_cast<int>(height_));
-        for (uint32_t y = 0; y < height_; ++y) {
-          const uint8_t* src_row = grey + y * bytes_per_line_;
-          uint8_t* dst_row = image.ptr() + y * width_ * 3;
-          for (uint32_t x = 0; x < width_; ++x) {
-            const uint8_t value = src_row[x];
-            dst_row[x * 3 + 0] = value;
-            dst_row[x * 3 + 1] = value;
-            dst_row[x * 3 + 2] = value;
-          }
-        }
-      }
-
-      if (xioctl_retry(fd_, VIDIOC_QBUF, &buffer) == -1) {
-        spdlog::error("FaceAuth: VIDIOC_QBUF failed for {}: {}", device_path_, std::strerror(errno));
-        close();
-        return {};
-      }
-
-      if (!image.empty()) {
-        return image;
-      }
-    }
-
-    return {};
-  }
-
- private:
-  struct MappedBuffer {
-    void* start = MAP_FAILED;
-    size_t length = 0;
+  struct Mapping {
+    void* base = nullptr;
+    size_t size = 0;
+    size_t plane_offset = 0;
   };
 
-  void close() {
-    if (fd_ >= 0 && stream_started_) {
-      xioctl_retry(fd_, VIDIOC_STREAMOFF, &buffer_type_);
-      stream_started_ = false;
-    }
-
-    for (auto& buffer : buffers_) {
-      if (buffer.start != MAP_FAILED) {
-        ::munmap(buffer.start, buffer.length);
-        buffer.start = MAP_FAILED;
-        buffer.length = 0;
-      }
-    }
-    buffers_.clear();
-
-    if (fd_ >= 0) {
-      ::close(fd_);
-      fd_ = -1;
-    }
-  }
-
-  std::string device_path_;
-  int fd_ = -1;
-  uint32_t width_ = 0;
-  uint32_t height_ = 0;
-  uint32_t bytes_per_line_ = 0;
+  std::shared_ptr<libcamera::CameraManager> manager_;
+  std::shared_ptr<libcamera::Camera> camera_;
+  std::string camera_label_;
+  bool is_grey_ = false;
   int warmup_frames_ = 0;
   int capture_timeout_ms_ = 0;
-  int poll_interval_ms_ = 0;
-  std::vector<MappedBuffer> buffers_;
-  v4l2_buf_type buffer_type_ = V4L2_BUF_TYPE_VIDEO_CAPTURE;
-  bool stream_started_ = false;
+  bool warmed_up_ = false;
+
+  std::unique_ptr<libcamera::CameraConfiguration> config_;
+  libcamera::Stream* stream_ = nullptr;
+  libcamera::PixelFormat pixel_format_;
+  int width_ = 0;
+  int height_ = 0;
+  int stride_ = 0;
+
+  std::unique_ptr<libcamera::FrameBufferAllocator> allocator_;
+  std::vector<std::unique_ptr<libcamera::Request>> requests_;
+  std::map<libcamera::FrameBuffer*, Mapping> mappings_;
+
+  std::mutex mutex_;
+  std::condition_variable ready_;
+  std::deque<libcamera::Request*> completed_;
+  int connection_token_ = 0;
+
+  bool acquired_ = false;
+  bool started_ = false;
 };
-
-void captureLogCallback(uint32_t level, const char* message) {
-  if (!message) {
-    return;
-  }
-  if (std::strstr(message, "tjDecompressHeader2 failed: No error") != nullptr) {
-    return;
-  }
-
-  std::string msg(message);
-  while (!msg.empty() && (msg.back() == '\n' || msg.back() == '\r')) {
-    msg.pop_back();
-  }
-
-  if (level <= 3) {
-    spdlog::error("openpnp-capture: {}", msg);
-  } else if (level == 4) {
-    spdlog::warn("openpnp-capture: {}", msg);
-  } else {
-    spdlog::info("openpnp-capture: {}", msg);
-  }
-}
-
-void captureLog() {
-  static std::once_flag once;
-  std::call_once(once, []() { Cap_installCustomLogFunction(captureLogCallback); });
-}
-
-std::optional<CapDeviceID> resolveCameraDeviceIdx(
-    CapContext ctx, const std::optional<std::string>& linux_video_device_path) {
-  const uint32_t count = Cap_getDeviceCount(ctx);
-  if (count == 0) {
-    spdlog::error("FaceAuth: No camera devices reported by openpnp-capture");
-    return std::nullopt;
-  }
-
-  if (linux_video_device_path.has_value()) {
-    const auto capture_paths = enumerate_linux_video_capture_paths();
-    for (size_t index = 0; index < capture_paths.size(); ++index) {
-      if (capture_paths[index] == *linux_video_device_path) {
-        if (index < count) {
-          return static_cast<CapDeviceID>(index);
-        }
-        spdlog::error(
-            "FaceAuth: Camera path '{}' resolved to index {} but openpnp reports only {} device(s)",
-            *linux_video_device_path, index, count);
-        return std::nullopt;
-      }
-    }
-
-    for (uint32_t i = 0; i < count; ++i) {
-      const char* uid = Cap_getDeviceUniqueID(ctx, static_cast<CapDeviceID>(i));
-      if (uid && std::string(uid).find(*linux_video_device_path) != std::string::npos) {
-        return static_cast<CapDeviceID>(i);
-      }
-    }
-
-    spdlog::error("FaceAuth: Camera path '{}' was not found among capture-capable /dev/video* devices",
-                  *linux_video_device_path);
-    return std::nullopt;
-  }
-
-  return static_cast<CapDeviceID>(0);
-}
 
 }  // namespace
 
@@ -483,102 +541,26 @@ bool checkCameraAvailability(const std::optional<std::string>& linux_video_devic
 
 std::unique_ptr<ICameraCaptureSession> openCameraSession(
     const std::optional<std::string>& linux_video_device_path, CameraCaptureFormat format,
-    int warmup_frames, int capture_timeout_ms, int poll_interval_ms) {
-  captureLog();
-  CapContext ctx = Cap_createContext();
-  if (!ctx) {
-    spdlog::error("FaceAuth: Failed to create capture context for '{}'",
-                  device_label(linux_video_device_path));
+    int warmup_frames, int capture_timeout_ms) {
+  auto manager = cameraManager();
+  if (!manager) {
     return nullptr;
   }
 
-  const auto device_index = resolveCameraDeviceIdx(ctx, linux_video_device_path);
-  if (!device_index.has_value()) {
-    Cap_releaseContext(ctx);
+  auto camera = findCamera(*manager, linux_video_device_path);
+  if (!camera) {
     return nullptr;
   }
 
-  if (format == CameraCaptureFormat::V4L2Grey) {
-    if (!linux_video_device_path.has_value()) {
-      spdlog::error("FaceAuth: Direct V4L2 GREY capture requires a /dev/video* path");
-      Cap_releaseContext(ctx);
-      return nullptr;
-    }
-
-    const auto grey_format = find_camera_format_by_fourcc(ctx, *device_index, V4L2_PIX_FMT_GREY);
-    if (!grey_format.has_value()) {
-      spdlog::error("FaceAuth: Camera '{}' does not expose a GREY format for direct V4L2 capture",
-                    *linux_video_device_path);
-      Cap_releaseContext(ctx);
-      return nullptr;
-    }
-
-    Cap_releaseContext(ctx);
-    auto session = std::make_unique<V4L2GreyCameraSession>(*linux_video_device_path, *grey_format,
-                                                           warmup_frames, capture_timeout_ms,
-                                                           poll_interval_ms);
-    if (!session->isOpen()) {
-      return nullptr;
-    }
-    return session;
-  }
-
-  CapFormatInfo fmt {};
-  CapResult fmt_result = Cap_getFormatInfo(ctx, *device_index, 0, &fmt);
-  if (fmt_result != CAPRESULT_OK) {
-    spdlog::error("FaceAuth: Failed to get camera format info for '{}' (index {}, code {})",
-                  device_label(linux_video_device_path), *device_index, static_cast<int>(fmt_result));
-    Cap_releaseContext(ctx);
-    return nullptr;
-  }
-
-  if (fmt.fourcc == V4L2_PIX_FMT_GREY) {
-    auto linux_path = linux_video_device_path;
-    if (!linux_path.has_value()) {
-      linux_path = linux_device_path_from_index(*device_index);
-    }
-
-    if (!linux_path.has_value()) {
-      spdlog::error(
-          "FaceAuth: Device index {} requires GREY fallback but has no resolvable /dev/video path",
-          *device_index);
-      Cap_releaseContext(ctx);
-      return nullptr;
-    }
-
-    spdlog::warn(
-        "FaceAuth: Device '{}' reports GREY format; using V4L2 GREY fallback on '{}'",
-        device_label(linux_video_device_path), *linux_path);
-    Cap_releaseContext(ctx);
-    auto session = std::make_unique<V4L2GreyCameraSession>(*linux_path, fmt, warmup_frames,
-                                                           capture_timeout_ms, poll_interval_ms);
-    if (!session->isOpen()) {
-      return nullptr;
-    }
-    return session;
-  }
-
-  CapStream stream = Cap_openStream(ctx, *device_index, 0);
-  if (stream < 0 || !Cap_isOpenStream(ctx, stream)) {
-    spdlog::error("FaceAuth: Failed to open camera stream for '{}' (index {})",
-                  device_label(linux_video_device_path), *device_index);
-    Cap_releaseContext(ctx);
-    return nullptr;
-  }
-
-  auto session = std::make_unique<OpenPnpCameraSession>(
-      ctx, stream, fmt.width, fmt.height, device_label(linux_video_device_path), capture_timeout_ms,
-      poll_interval_ms);
-  if (!session->isOpen()) {
-    return nullptr;
-  }
-  return session;
+  return LibcameraCaptureSession::open(manager, camera, format,
+                                       device_label(linux_video_device_path), warmup_frames,
+                                       capture_timeout_ms);
 }
 
 ImageRGB captureImage(const std::optional<std::string>& linux_video_device_path,
                       CameraCaptureFormat format) {
   auto session = openCameraSession(linux_video_device_path, format, kDefaultWarmupFrames,
-                                   kDefaultCaptureTimeoutMs, kDefaultCapturePollIntervalMs);
+                                   kDefaultCaptureTimeoutMs);
   if (!session) {
     return {};
   }
@@ -587,19 +569,67 @@ ImageRGB captureImage(const std::optional<std::string>& linux_video_device_path,
 }
 
 ImageRGB captureImageByIRCamera(const std::string& device_path, int warmup_frames,
-                                int capture_timeout_ms, int poll_interval_ms) {
+                                int capture_timeout_ms) {
   if (device_path.empty()) {
     spdlog::error("FaceAuth: IR camera capture requires a /dev/video* path");
     return {};
   }
 
   auto session = openCameraSession(device_path, CameraCaptureFormat::V4L2Grey, warmup_frames,
-                                   capture_timeout_ms, poll_interval_ms);
+                                   capture_timeout_ms);
   if (!session) {
     return {};
   }
 
   return session->capture();
+}
+
+std::vector<CameraDeviceInfo> listCameraDevices() {
+  std::vector<CameraDeviceInfo> result;
+  auto manager = cameraManager();
+  if (!manager) {
+    return result;
+  }
+
+  for (const auto& camera : manager->cameras()) {
+    CameraDeviceInfo info;
+    info.id = camera->id();
+    const auto model = camera->properties().get(libcamera::properties::Model);
+    info.model = model ? std::string(*model) : info.id;
+    info.video_paths = videoPathsForCamera(*camera);
+    result.push_back(std::move(info));
+  }
+  return result;
+}
+
+std::vector<CameraFormatDesc> listCameraFormats(const std::string& device_path) {
+  std::vector<CameraFormatDesc> result;
+  auto manager = cameraManager();
+  if (!manager) {
+    return result;
+  }
+
+  auto camera = findCameraByPath(*manager, device_path);
+  if (!camera) {
+    return result;
+  }
+
+  auto config = camera->generateConfiguration({libcamera::StreamRole::StillCapture});
+  if (!config || config->size() == 0) {
+    return result;
+  }
+
+  const auto& formats = config->at(0).formats();
+  for (const auto& pixel_format : formats.pixelformats()) {
+    CameraFormatDesc desc;
+    desc.pixel_format = pixel_format.toString();
+    desc.supported = isSupportedPixelFormat(pixel_format);
+    for (const auto& size : formats.sizes(pixel_format)) {
+      desc.sizes.emplace_back(static_cast<int>(size.width), static_cast<int>(size.height));
+    }
+    result.push_back(std::move(desc));
+  }
+  return result;
 }
 
 }  // namespace biopass

--- a/auth/face/common/camera_capture.h
+++ b/auth/face/common/camera_capture.h
@@ -12,7 +12,9 @@ namespace biopass {
 
 enum class CameraCaptureFormat {
   Default,   // Preference order: YUYV -> MJPEG -> R8 (grey).
-  V4L2Grey,  // Requires the camera to expose a GREY/R8 stream (IR sensors).
+  V4L2Grey,  // IR sensors. Preference order: R8 (grey) -> YUYV -> MJPEG,
+             // since some IR sensors (e.g. Windows Hello cameras) only
+             // expose the stream as YUYV/MJPEG.
 };
 
 // Shared tuning for IR (V4L2Grey) camera sessions: more warmup frames and a

--- a/auth/face/common/camera_capture.h
+++ b/auth/face/common/camera_capture.h
@@ -3,15 +3,23 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <utility>
+#include <vector>
 
 #include "image_utils.h"
 
 namespace biopass {
 
 enum class CameraCaptureFormat {
-  Default,
-  V4L2Grey,
+  Default,   // Preference order: YUYV -> MJPEG -> R8 (grey).
+  V4L2Grey,  // Requires the camera to expose a GREY/R8 stream (IR sensors).
 };
+
+// Shared tuning for IR (V4L2Grey) camera sessions: more warmup frames and a
+// shorter timeout than the default color capture, since IR sensors settle
+// faster and the anti-spoofing check should fail fast rather than block login.
+constexpr int kIrCaptureWarmupFrames = 5;
+constexpr int kIrCaptureTimeoutMs = 3000;
 
 class ICameraCaptureSession {
  public:
@@ -23,12 +31,27 @@ class ICameraCaptureSession {
 bool checkCameraAvailability(const std::optional<std::string>& device_path);
 std::unique_ptr<ICameraCaptureSession> openCameraSession(
     const std::optional<std::string>& device_path,
-    CameraCaptureFormat format = CameraCaptureFormat::Default,
-    int warmup_frames = 5, int capture_timeout_ms = 10000, int poll_interval_ms = 10);
-ImageRGB captureImage(
-    const std::optional<std::string>& device_path,
-    CameraCaptureFormat format = CameraCaptureFormat::Default);
-ImageRGB captureImageByIRCamera(const std::string& device_path, int warmup_frames = 5,
-                              int capture_timeout_ms = 3000, int poll_interval_ms = 10);
+    CameraCaptureFormat format = CameraCaptureFormat::Default, int warmup_frames = 5,
+    int capture_timeout_ms = 10000);
+ImageRGB captureImage(const std::optional<std::string>& device_path,
+                      CameraCaptureFormat format = CameraCaptureFormat::Default);
+ImageRGB captureImageByIRCamera(const std::string& device_path,
+                                int warmup_frames = kIrCaptureWarmupFrames,
+                                int capture_timeout_ms = kIrCaptureTimeoutMs);
+
+// Introspection helpers used by camera_capture_test (field debugging).
+struct CameraDeviceInfo {
+  std::string id;
+  std::string model;
+  std::vector<std::string> video_paths;
+};
+std::vector<CameraDeviceInfo> listCameraDevices();
+
+struct CameraFormatDesc {
+  std::string pixel_format;
+  std::vector<std::pair<int, int>> sizes;
+  bool supported = false;
+};
+std::vector<CameraFormatDesc> listCameraFormats(const std::string& device_path);
 
 }  // namespace biopass

--- a/auth/face/common/onnx_session.cc
+++ b/auth/face/common/onnx_session.cc
@@ -1,0 +1,35 @@
+#include "onnx_session.h"
+
+namespace biopass {
+
+OnnxSession::OnnxSession(const std::string& model_path, const char* log_name)
+    : env_(ORT_LOGGING_LEVEL_WARNING, log_name) {
+  Ort::SessionOptions opts;
+  opts.SetIntraOpNumThreads(1);
+  opts.SetGraphOptimizationLevel(GraphOptimizationLevel::ORT_ENABLE_ALL);
+
+  session_ = std::make_unique<Ort::Session>(env_, model_path.c_str(), opts);
+
+  for (size_t i = 0; i < session_->GetInputCount(); i++) {
+    auto name = session_->GetInputNameAllocated(i, allocator_);
+    input_names_str_.push_back(name.get());
+  }
+  for (size_t i = 0; i < session_->GetOutputCount(); i++) {
+    auto name = session_->GetOutputNameAllocated(i, allocator_);
+    output_names_str_.push_back(name.get());
+  }
+  for (auto& s : input_names_str_) input_names_cstr_.push_back(s.c_str());
+  for (auto& s : output_names_str_) output_names_cstr_.push_back(s.c_str());
+}
+
+std::vector<Ort::Value> OnnxSession::run(std::vector<float>& input,
+                                         const std::vector<int64_t>& shape) {
+  auto memory_info = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
+  Ort::Value input_tensor = Ort::Value::CreateTensor<float>(memory_info, input.data(), input.size(),
+                                                            shape.data(), shape.size());
+
+  return session_->Run(Ort::RunOptions{nullptr}, input_names_cstr_.data(), &input_tensor, 1,
+                       output_names_cstr_.data(), output_names_cstr_.size());
+}
+
+}  // namespace biopass

--- a/auth/face/common/onnx_session.h
+++ b/auth/face/common/onnx_session.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <onnxruntime_cxx_api.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace biopass {
+
+// Owns the ONNX Runtime session plumbing (env, session, allocator, I/O name
+// tables) shared by every inference engine in this module (detection,
+// recognition, anti-spoofing). Engines compose this and only implement their
+// own pre/postprocessing.
+class OnnxSession {
+ public:
+  OnnxSession(const std::string& model_path, const char* log_name);
+
+  std::vector<Ort::Value> run(std::vector<float>& input, const std::vector<int64_t>& shape);
+
+ private:
+  Ort::Env env_;
+  std::unique_ptr<Ort::Session> session_;
+  Ort::AllocatorWithDefaultOptions allocator_;
+  std::vector<std::string> input_names_str_;
+  std::vector<std::string> output_names_str_;
+  std::vector<const char*> input_names_cstr_;
+  std::vector<const char*> output_names_cstr_;
+};
+
+}  // namespace biopass

--- a/auth/face/common/pixel_convert.cc
+++ b/auth/face/common/pixel_convert.cc
@@ -1,0 +1,112 @@
+#include "pixel_convert.h"
+
+#include <turbojpeg.h>
+
+#include <algorithm>
+#include <cstring>
+
+namespace biopass {
+
+namespace {
+
+inline uint8_t clamp_u8(int value) {
+  return static_cast<uint8_t>(std::min(255, std::max(0, value)));
+}
+
+// BT.601 limited-range YUV -> RGB.
+inline void yuvToRgbPixel(int y, int u, int v, uint8_t* dst) {
+  const int c = y - 16;
+  const int d = u - 128;
+  const int e = v - 128;
+  dst[0] = clamp_u8((298 * c + 409 * e + 128) >> 8);
+  dst[1] = clamp_u8((298 * c - 100 * d - 208 * e + 128) >> 8);
+  dst[2] = clamp_u8((298 * c + 516 * d + 128) >> 8);
+}
+
+}  // namespace
+
+bool yuyvToRgb(const uint8_t* src, size_t size, int width, int height, int stride, ImageRGB& out) {
+  if (!src || width <= 0 || height <= 0) {
+    return false;
+  }
+  const size_t min_stride = static_cast<size_t>(width) * 2;
+  const size_t row_stride = static_cast<size_t>(std::max(stride, static_cast<int>(min_stride)));
+  const size_t required = row_stride * static_cast<size_t>(height - 1) + min_stride;
+  if (size < required) {
+    return false;
+  }
+
+  out = ImageRGB(width, height);
+  for (int y = 0; y < height; ++y) {
+    const uint8_t* src_row = src + static_cast<size_t>(y) * row_stride;
+    uint8_t* dst_row = out.ptr() + static_cast<size_t>(y) * width * 3;
+    for (int x = 0; x + 1 < width; x += 2) {
+      const uint8_t y0 = src_row[x * 2 + 0];
+      const uint8_t u = src_row[x * 2 + 1];
+      const uint8_t y1 = src_row[x * 2 + 2];
+      const uint8_t v = src_row[x * 2 + 3];
+      yuvToRgbPixel(y0, u, v, dst_row + x * 3);
+      yuvToRgbPixel(y1, u, v, dst_row + (x + 1) * 3);
+    }
+    // YUYV encodes pixels in pairs; a trailing unpaired column (odd width,
+    // which real cameras never report) is left black.
+  }
+  return true;
+}
+
+bool greyToRgb(const uint8_t* src, size_t size, int width, int height, int stride, ImageRGB& out) {
+  if (!src || width <= 0 || height <= 0) {
+    return false;
+  }
+  const size_t row_stride = static_cast<size_t>(std::max(stride, width));
+  const size_t required = row_stride * static_cast<size_t>(height - 1) + static_cast<size_t>(width);
+  if (size < required) {
+    return false;
+  }
+
+  out = ImageRGB(width, height);
+  for (int y = 0; y < height; ++y) {
+    const uint8_t* src_row = src + static_cast<size_t>(y) * row_stride;
+    uint8_t* dst_row = out.ptr() + static_cast<size_t>(y) * width * 3;
+    for (int x = 0; x < width; ++x) {
+      const uint8_t value = src_row[x];
+      dst_row[x * 3 + 0] = value;
+      dst_row[x * 3 + 1] = value;
+      dst_row[x * 3 + 2] = value;
+    }
+  }
+  return true;
+}
+
+bool mjpegToRgb(const uint8_t* src, size_t bytes_used, ImageRGB& out) {
+  if (!src || bytes_used < 2 || src[0] != 0xFF || src[1] != 0xD8) {
+    return false;
+  }
+
+  tjhandle handle = tjInitDecompress();
+  if (!handle) {
+    return false;
+  }
+
+  int width = 0, height = 0, subsamp = 0, colorspace = 0;
+  if (tjDecompressHeader3(handle, const_cast<unsigned char*>(src),
+                          static_cast<unsigned long>(bytes_used), &width, &height, &subsamp,
+                          &colorspace) != 0 ||
+      width <= 0 || height <= 0) {
+    tjDestroy(handle);
+    return false;
+  }
+
+  out = ImageRGB(width, height);
+  const int rc = tjDecompress2(handle, const_cast<unsigned char*>(src),
+                               static_cast<unsigned long>(bytes_used), out.ptr(), width,
+                               0 /* pitch: tightly packed */, height, TJPF_RGB, TJFLAG_FASTDCT);
+  tjDestroy(handle);
+  if (rc != 0) {
+    out = ImageRGB();
+    return false;
+  }
+  return true;
+}
+
+}  // namespace biopass

--- a/auth/face/common/pixel_convert.h
+++ b/auth/face/common/pixel_convert.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "image_utils.h"
+
+namespace biopass {
+
+// Converts a packed YUYV (YUY2) buffer into RGB8. `stride` is the number of
+// bytes per row (may exceed width * 2 due to padding). Returns false if
+// `size` is too small for the declared width/height/stride.
+bool yuyvToRgb(const uint8_t* src, size_t size, int width, int height, int stride, ImageRGB& out);
+
+// Expands a packed single-channel GREY/R8 buffer into RGB8 by replicating
+// the channel. `stride` is the number of bytes per row.
+bool greyToRgb(const uint8_t* src, size_t size, int width, int height, int stride, ImageRGB& out);
+
+// Decodes a JPEG/MJPEG buffer (`bytes_used` valid bytes at `src`) into RGB8
+// via libjpeg-turbo. Returns false on decode failure or a non-JPEG buffer.
+bool mjpegToRgb(const uint8_t* src, size_t bytes_used, ImageRGB& out);
+
+}  // namespace biopass

--- a/auth/face/detection/CMakeLists.txt
+++ b/auth/face/detection/CMakeLists.txt
@@ -13,4 +13,5 @@ target_include_directories(biopass_det PUBLIC
 target_link_libraries(biopass_det PRIVATE
     ${ONNXRUNTIME_LIB}
     biopass_stb
+    biopass_onnx
 )

--- a/auth/face/detection/face_detection.cc
+++ b/auth/face/detection/face_detection.cc
@@ -4,66 +4,25 @@
 
 #include "utils.h"
 
-FaceDetection::FaceDetection(const std::string &ckpt, int imgsz,
-                             const std::vector<std::string> &classes, const float conf,
-                             const float iou) {
-  this->ckpt = ckpt;
-  this->imgsz = imgsz;
-  this->conf = conf;
-  this->iou = iou;
-  this->classes = classes;
+namespace biopass {
 
-  this->loadModel(ckpt);
-}
+FaceDetection::FaceDetection(const std::string& ckpt, int imgsz, const float conf, const float iou)
+    : conf(conf), iou(iou), imgsz(imgsz), session(ckpt, "FaceDetection") {}
 
-void FaceDetection::loadModel(const std::string &ckpt) {
-  this->ckpt = ckpt;
-
-  Ort::SessionOptions opts;
-  opts.SetIntraOpNumThreads(1);
-  opts.SetGraphOptimizationLevel(GraphOptimizationLevel::ORT_ENABLE_ALL);
-
-  this->session = std::make_unique<Ort::Session>(this->env, ckpt.c_str(), opts);
-
-  this->input_names_str.clear();
-  this->output_names_str.clear();
-  this->input_names_cstr.clear();
-  this->output_names_cstr.clear();
-
-  for (size_t i = 0; i < this->session->GetInputCount(); i++) {
-    auto name = this->session->GetInputNameAllocated(i, this->allocator);
-    this->input_names_str.push_back(name.get());
-  }
-  for (size_t i = 0; i < this->session->GetOutputCount(); i++) {
-    auto name = this->session->GetOutputNameAllocated(i, this->allocator);
-    this->output_names_str.push_back(name.get());
-  }
-  for (auto &s : this->input_names_str)
-    this->input_names_cstr.push_back(s.c_str());
-  for (auto &s : this->output_names_str)
-    this->output_names_cstr.push_back(s.c_str());
-}
-
-std::vector<Detection> FaceDetection::inference(const ImageRGB &image) {
+std::vector<Detection> FaceDetection::inference(const ImageRGB& image) {
   // Preprocess
   ImageRGB input_image = imageLetterbox(image, this->imgsz, this->imgsz);
   std::vector<float> image_data = this->preprocess(input_image);
 
   // Inference
   std::vector<int64_t> input_shape = {1, 3, (int64_t)this->imgsz, (int64_t)this->imgsz};
-  auto memory_info = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
-  Ort::Value input_tensor = Ort::Value::CreateTensor<float>(
-      memory_info, image_data.data(), image_data.size(), input_shape.data(), input_shape.size());
+  auto output_tensors = this->session.run(image_data, input_shape);
 
-  auto output_tensors =
-      this->session->Run(Ort::RunOptions{nullptr}, this->input_names_cstr.data(), &input_tensor, 1,
-                         this->output_names_cstr.data(), this->output_names_cstr.size());
-
-  auto &out = output_tensors[0];
+  auto& out = output_tensors[0];
   auto shape = out.GetTensorTypeAndShapeInfo().GetShape();
   int pred_dim = static_cast<int>(shape[1]);
   int num_preds = static_cast<int>(shape[2]);
-  const float *output_data = out.GetTensorData<float>();
+  const float* output_data = out.GetTensorData<float>();
 
   // NMS
   auto raw_dets = non_max_suppression(output_data, num_preds, pred_dim, this->conf, this->iou);
@@ -71,7 +30,7 @@ std::vector<Detection> FaceDetection::inference(const ImageRGB &image) {
 
   // Get detection results
   std::vector<Detection> results;
-  for (auto &d : raw_dets) {
+  for (auto& d : raw_dets) {
     int x1 = std::max(0, (int)d.x1);
     int y1 = std::max(0, (int)d.y1);
     int x2 = std::min(image.width, (int)d.x2);
@@ -92,6 +51,8 @@ std::vector<Detection> FaceDetection::inference(const ImageRGB &image) {
   return results;
 }
 
-std::vector<float> FaceDetection::preprocess(const ImageRGB &input_image) {
+std::vector<float> FaceDetection::preprocess(const ImageRGB& input_image) {
   return imageToChw(input_image);
 }
+
+}  // namespace biopass

--- a/auth/face/detection/face_detection.h
+++ b/auth/face/detection/face_detection.h
@@ -2,16 +2,14 @@
 #define FACE_DET_H
 
 // CPP native
-#include <fstream>
-#include <random>
 #include <string>
 #include <vector>
 
 // Image utilities (replaces OpenCV)
 #include "image_utils.h"
+#include "onnx_session.h"
 
-// ONNX Runtime
-#include <onnxruntime_cxx_api.h>
+namespace biopass {
 
 struct Box {
   int x1, y1, x2, y2;
@@ -37,28 +35,20 @@ struct Detection {
 
 class FaceDetection {
  public:
-  FaceDetection(const std::string& ckpt, int imgsz = 640,
-                const std::vector<std::string>& classes = {"face"}, const float conf = 0.50,
+  FaceDetection(const std::string& ckpt, int imgsz = 640, const float conf = 0.50,
                 const float iou = 0.50);
 
-  void loadModel(const std::string& ckpt);
   std::vector<Detection> inference(const ImageRGB& image);
-  std::vector<float> preprocess(const ImageRGB& image);
 
  private:
+  std::vector<float> preprocess(const ImageRGB& image);
+
   float conf;
   float iou;
   int imgsz;
-  std::string ckpt{};
-  std::vector<std::string> classes{"face"};
-
-  Ort::Env env{ORT_LOGGING_LEVEL_WARNING, "FaceDetection"};
-  std::unique_ptr<Ort::Session> session;
-  Ort::AllocatorWithDefaultOptions allocator;
-  std::vector<std::string> input_names_str;
-  std::vector<std::string> output_names_str;
-  std::vector<const char*> input_names_cstr;
-  std::vector<const char*> output_names_cstr;
+  OnnxSession session;
 };
+
+}  // namespace biopass
 
 #endif  // FACE_DET_H

--- a/auth/face/detection/utils.cc
+++ b/auth/face/detection/utils.cc
@@ -4,7 +4,11 @@
 #include <cmath>
 #include <numeric>
 
-static std::vector<int> nms(const std::vector<RawDet>& dets, float iou_threshold) {
+namespace biopass {
+
+namespace {
+
+std::vector<int> nms(const std::vector<RawDet>& dets, float iou_threshold) {
   if (dets.empty())
     return {};
 
@@ -46,6 +50,8 @@ static std::vector<int> nms(const std::vector<RawDet>& dets, float iou_threshold
   }
   return keep;
 }
+
+}  // namespace
 
 std::vector<RawDet> non_max_suppression(const float* output, int num_preds, int pred_dim,
                                         float conf_thres, float iou_thres, int max_det) {
@@ -105,3 +111,5 @@ void scale_boxes(const std::vector<int>& img1_shape, std::vector<RawDet>& dets,
     d.y2 = (d.y2 - pad1) / gain;
   }
 }
+
+}  // namespace biopass

--- a/auth/face/detection/utils.h
+++ b/auth/face/detection/utils.h
@@ -4,6 +4,8 @@
 // CPP native
 #include <vector>
 
+namespace biopass {
+
 struct RawDet {
   float x1, y1, x2, y2, conf;
   int cls;
@@ -15,5 +17,7 @@ std::vector<RawDet> non_max_suppression(const float* output, int num_preds, int 
 
 void scale_boxes(const std::vector<int>& img1_shape, std::vector<RawDet>& dets,
                  const std::vector<int>& img0_shape);
+
+}  // namespace biopass
 
 #endif  // FACE_DET_UTILS_H

--- a/auth/face/face_auth.cc
+++ b/auth/face/face_auth.cc
@@ -10,33 +10,72 @@
 #include "antispoof_check.h"
 #include "camera_capture.h"
 #include "debug_image_io.h"
-#include "face_detection.h"
-#include "face_recognition.h"
 #include "image_utils.h"
 
 namespace biopass {
 
-namespace {
-
-constexpr int kIrCaptureWarmupFrames = 5;
-constexpr int kIrCaptureTimeoutMs = 3000;
-constexpr int kIrCapturePollIntervalMs = 10;
-
-}  // namespace
-
 bool FaceAuth::isAvailable() const { return checkCameraAvailability(face_config_.camera); }
+
+void FaceAuth::ensureIrSession() {
+  if (face_config_.anti_spoofing.ir_camera.has_value() &&
+      !face_config_.anti_spoofing.ir_camera->empty() &&
+      (!ir_camera_session_ || !ir_camera_session_->isOpen())) {
+    ir_camera_session_ =
+        openCameraSession(*face_config_.anti_spoofing.ir_camera, CameraCaptureFormat::V4L2Grey,
+                          kIrCaptureWarmupFrames, kIrCaptureTimeoutMs);
+  }
+}
+
+bool FaceAuth::ensureModelsLoaded() {
+  if (detector_ && recognizer_) {
+    return true;
+  }
+
+  const std::string& recogModelPath = face_config_.recognition.model;
+  const std::string& detectModelPath = face_config_.detection.model;
+  if (!std::ifstream(recogModelPath).good() || !std::ifstream(detectModelPath).good()) {
+    spdlog::error("FaceAuth: Model files not found");
+    return false;
+  }
+
+  try {
+    detector_ =
+        std::make_unique<FaceDetection>(detectModelPath, 640, face_config_.detection.threshold);
+    spdlog::debug("FaceAuth: Detection model loaded | threshold={:.3f}",
+                  face_config_.detection.threshold);
+  } catch (const std::exception& e) {
+    std::string msg = e.what();
+    size_t first_line = msg.find('\n');
+    if (first_line != std::string::npos)
+      msg = msg.substr(0, first_line);
+    spdlog::error("FaceAuth: Failed to load detection model: {}, skipping", msg);
+    return false;
+  }
+
+  try {
+    recognizer_ =
+        std::make_unique<FaceRecognition>(recogModelPath, 112, face_config_.recognition.threshold);
+    spdlog::debug("FaceAuth: Recognition model loaded | threshold={:.3f}",
+                  face_config_.recognition.threshold);
+  } catch (const std::exception& e) {
+    std::string msg = e.what();
+    size_t first_line = msg.find('\n');
+    if (first_line != std::string::npos)
+      msg = msg.substr(0, first_line);
+    spdlog::error("FaceAuth: Failed to load recognition model: {}, skipping", msg);
+    detector_.reset();
+    return false;
+  }
+
+  return true;
+}
 
 void FaceAuth::beginAuthenticationSession() {
   if (!camera_session_) {
     camera_session_ = openCameraSession(face_config_.camera);
   }
-
-  if (face_config_.anti_spoofing.ir_camera.has_value() &&
-      !face_config_.anti_spoofing.ir_camera->empty() && !ir_camera_session_) {
-    ir_camera_session_ =
-        openCameraSession(*face_config_.anti_spoofing.ir_camera, CameraCaptureFormat::V4L2Grey,
-                          kIrCaptureWarmupFrames, kIrCaptureTimeoutMs, kIrCapturePollIntervalMs);
-  }
+  ensureIrSession();
+  ensureModelsLoaded();
 }
 
 void FaceAuth::endAuthenticationSession() {
@@ -63,41 +102,8 @@ AuthResult FaceAuth::authenticate(const std::string& username, const AuthConfig&
     return AuthResult::Unavailable;
   }
 
-  std::string recogModelPath = face_config_.recognition.model;
-  std::string detectModelPath = face_config_.detection.model;
-  if (!std::ifstream(recogModelPath).good() || !std::ifstream(detectModelPath).good()) {
-    spdlog::error("FaceAuth: Model files not found for user {}, skipping", username);
-    return AuthResult::Unavailable;
-  }
-
-  std::unique_ptr<FaceRecognition> faceReg;
-  std::unique_ptr<FaceDetection> detector;
-  try {
-    detector = std::make_unique<FaceDetection>(
-        detectModelPath, 640, std::vector<std::string>{"face"},
-        face_config_.detection.threshold);
-    spdlog::debug("FaceAuth: Detection model loaded | threshold={:.3f}",
-                  face_config_.detection.threshold);
-  } catch (const std::exception& e) {
-    std::string msg = e.what();
-    size_t first_line = msg.find('\n');
-    if (first_line != std::string::npos)
-      msg = msg.substr(0, first_line);
-    spdlog::error("FaceAuth: Failed to load detection model: {}, skipping", msg);
-    return AuthResult::Unavailable;
-  }
-
-  try {
-    faceReg = std::make_unique<FaceRecognition>(
-        recogModelPath, 112, face_config_.recognition.threshold);
-    spdlog::debug("FaceAuth: Recognition model loaded | threshold={:.3f}",
-                  face_config_.recognition.threshold);
-  } catch (const std::exception& e) {
-    std::string msg = e.what();
-    size_t first_line = msg.find('\n');
-    if (first_line != std::string::npos)
-      msg = msg.substr(0, first_line);
-    spdlog::error("FaceAuth: Failed to load recognition model: {}, skipping", msg);
+  if (!ensureModelsLoaded()) {
+    spdlog::error("FaceAuth: Models not available for user {}, skipping", username);
     return AuthResult::Unavailable;
   }
 
@@ -112,7 +118,7 @@ AuthResult FaceAuth::authenticate(const std::string& username, const AuthConfig&
     return AuthResult::Retry;
   }
 
-  std::vector<Detection> detectedImages = detector->inference(loginFace);
+  std::vector<Detection> detectedImages = detector_->inference(loginFace);
   if (detectedImages.empty()) {
     spdlog::error("FaceAuth: No face detected");
     return AuthResult::Retry;
@@ -120,15 +126,10 @@ AuthResult FaceAuth::authenticate(const std::string& username, const AuthConfig&
 
   ImageRGB face = detectedImages[0].image;
 
-  if (face_config_.anti_spoofing.ir_camera.has_value() &&
-      !face_config_.anti_spoofing.ir_camera->empty() &&
-      (!ir_camera_session_ || !ir_camera_session_->isOpen())) {
-    ir_camera_session_ =
-        openCameraSession(*face_config_.anti_spoofing.ir_camera, CameraCaptureFormat::V4L2Grey,
-                          kIrCaptureWarmupFrames, kIrCaptureTimeoutMs, kIrCapturePollIntervalMs);
-  }
+  ensureIrSession();
 
-  if (!checkAntiSpoof(face_config_, username, face, config, ir_camera_session_.get())) {
+  if (!checkAntiSpoof(face_config_, username, face, config, detector_.get(),
+                      ir_camera_session_.get())) {
     spdlog::warn("FaceAuth: Anti-spoofing failed — returning Failure (no retry allowed)");
     // Always tear down the IR session so a subsequent call cannot reuse a
     // partially-warmed camera to bypass the check.
@@ -146,12 +147,12 @@ AuthResult FaceAuth::authenticate(const std::string& username, const AuthConfig&
       continue;
     }
 
-    MatchResult match = faceReg->match(preparedFace, face);
+    MatchResult match = recognizer_->match(preparedFace, face);
     spdlog::debug("FaceAuth: Recognition | face='{}' score={:.4f} threshold={:.3f} similar={}",
                   facePath, match.dist, face_config_.recognition.threshold, match.similar);
     if (match.similar) {
-      spdlog::debug("FaceAuth: Recognition PASSED | matched face='{}' score={:.4f}",
-                    facePath, match.dist);
+      spdlog::debug("FaceAuth: Recognition PASSED | matched face='{}' score={:.4f}", facePath,
+                    match.dist);
       return AuthResult::Success;
     }
   }

--- a/auth/face/face_auth.h
+++ b/auth/face/face_auth.h
@@ -5,6 +5,8 @@
 #include "auth_config.h"
 #include "auth_method.h"
 #include "camera_capture.h"
+#include "face_detection.h"
+#include "face_recognition.h"
 
 namespace biopass {
 
@@ -14,7 +16,7 @@ namespace biopass {
  */
 class FaceAuth : public IAuthMethod {
  public:
-  explicit FaceAuth(const FaceMethodConfig &config) : face_config_(config) {}
+  explicit FaceAuth(const FaceMethodConfig& config) : face_config_(config) {}
   ~FaceAuth() override = default;
 
   std::string name() const override { return "Face"; }
@@ -23,13 +25,20 @@ class FaceAuth : public IAuthMethod {
   uint32_t getRetryDelayMs() const override { return face_config_.retry_delay; }
   void beginAuthenticationSession() override;
   void endAuthenticationSession() override;
-  AuthResult authenticate(const std::string &username, const AuthConfig &config,
-                          std::atomic<bool> *cancel_signal = nullptr) override;
+  AuthResult authenticate(const std::string& username, const AuthConfig& config,
+                          std::atomic<bool>* cancel_signal = nullptr) override;
 
  private:
+  void ensureIrSession();
+  // Loads the detection + recognition models once; returns false if either
+  // model file is missing or fails to load.
+  bool ensureModelsLoaded();
+
   FaceMethodConfig face_config_;
   std::unique_ptr<ICameraCaptureSession> camera_session_;
   std::unique_ptr<ICameraCaptureSession> ir_camera_session_;
+  std::unique_ptr<FaceDetection> detector_;
+  std::unique_ptr<FaceRecognition> recognizer_;
 };
 
 }  // namespace biopass

--- a/auth/face/recognition/CMakeLists.txt
+++ b/auth/face/recognition/CMakeLists.txt
@@ -12,4 +12,5 @@ target_include_directories(biopass_reg PUBLIC
 target_link_libraries(biopass_reg PRIVATE
     ${ONNXRUNTIME_LIB}
     biopass_stb
+    biopass_onnx
 )

--- a/auth/face/recognition/face_recognition.cc
+++ b/auth/face/recognition/face_recognition.cc
@@ -1,41 +1,12 @@
 #include "face_recognition.h"
 
 #include <cmath>
+#include <stdexcept>
 
-FaceRecognition::FaceRecognition(const std::string& ckpt, int imgsz, const float threshold) {
-  this->ckpt = ckpt;
-  this->imgsz = imgsz;
-  this->threshold = threshold;
-  this->loadModel(ckpt);
-}
+namespace biopass {
 
-void FaceRecognition::loadModel(const std::string& ckpt) {
-  this->ckpt = ckpt;
-
-  Ort::SessionOptions opts;
-  opts.SetIntraOpNumThreads(1);
-  opts.SetGraphOptimizationLevel(GraphOptimizationLevel::ORT_ENABLE_ALL);
-
-  this->session = std::make_unique<Ort::Session>(this->env, ckpt.c_str(), opts);
-
-  this->input_names_str.clear();
-  this->output_names_str.clear();
-  this->input_names_cstr.clear();
-  this->output_names_cstr.clear();
-
-  for (size_t i = 0; i < this->session->GetInputCount(); i++) {
-    auto name = this->session->GetInputNameAllocated(i, this->allocator);
-    this->input_names_str.push_back(name.get());
-  }
-  for (size_t i = 0; i < this->session->GetOutputCount(); i++) {
-    auto name = this->session->GetOutputNameAllocated(i, this->allocator);
-    this->output_names_str.push_back(name.get());
-  }
-  for (auto& s : this->input_names_str)
-    this->input_names_cstr.push_back(s.c_str());
-  for (auto& s : this->output_names_str)
-    this->output_names_cstr.push_back(s.c_str());
-}
+FaceRecognition::FaceRecognition(const std::string& ckpt, int imgsz, const float threshold)
+    : threshold(threshold), imgsz(imgsz), session(ckpt, "FaceRecognition") {}
 
 std::vector<float> FaceRecognition::preprocess(const ImageRGB& input_image) {
   ImageRGB resize_img = imageResizePad(input_image, this->imgsz, this->imgsz);
@@ -50,13 +21,7 @@ std::vector<float> FaceRecognition::inference(const ImageRGB& image) {
   std::vector<float> input_data = this->preprocess(image);
 
   std::vector<int64_t> input_shape = {1, 3, (int64_t)this->imgsz, (int64_t)this->imgsz};
-  auto memory_info = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
-  Ort::Value input_tensor = Ort::Value::CreateTensor<float>(
-      memory_info, input_data.data(), input_data.size(), input_shape.data(), input_shape.size());
-
-  auto output_tensors =
-      this->session->Run(Ort::RunOptions{nullptr}, this->input_names_cstr.data(), &input_tensor, 1,
-                         this->output_names_cstr.data(), this->output_names_cstr.size());
+  auto output_tensors = this->session.run(input_data, input_shape);
 
   auto& out = output_tensors[0];
   auto shape = out.GetTensorTypeAndShapeInfo().GetShape();
@@ -93,3 +58,5 @@ MatchResult FaceRecognition::match(const ImageRGB& image1, const ImageRGB& image
     similar = true;
   return MatchResult(distance, similar);
 }
+
+}  // namespace biopass

--- a/auth/face/recognition/face_recognition.h
+++ b/auth/face/recognition/face_recognition.h
@@ -6,14 +6,9 @@
 
 // Image utilities (replaces OpenCV)
 #include "image_utils.h"
+#include "onnx_session.h"
 
-// ONNX Runtime
-#include <onnxruntime_cxx_api.h>
-
-struct Recognition {
-  std::vector<float> feature;
-  Recognition(std::vector<float>& feature) : feature(feature) {}
-};
+namespace biopass {
 
 struct MatchResult {
   float dist;
@@ -25,25 +20,18 @@ class FaceRecognition {
  public:
   FaceRecognition(const std::string& ckpt, int imgsz = 112, const float threshold = 0.50);
 
-  void loadModel(const std::string& ckpt);
-  std::vector<float> inference(const ImageRGB& image);
-  std::vector<float> preprocess(const ImageRGB& image);
-
-  float cosine(const std::vector<float>& feat1, const std::vector<float>& feat2);
   MatchResult match(const ImageRGB& image1, const ImageRGB& image2);
 
  private:
-  std::string ckpt;
+  std::vector<float> inference(const ImageRGB& image);
+  std::vector<float> preprocess(const ImageRGB& image);
+  float cosine(const std::vector<float>& feat1, const std::vector<float>& feat2);
+
   float threshold;
   int imgsz;
-
-  Ort::Env env{ORT_LOGGING_LEVEL_WARNING, "FaceRecognition"};
-  std::unique_ptr<Ort::Session> session;
-  Ort::AllocatorWithDefaultOptions allocator;
-  std::vector<std::string> input_names_str;
-  std::vector<std::string> output_names_str;
-  std::vector<const char*> input_names_cstr;
-  std::vector<const char*> output_names_cstr;
+  OnnxSession session;
 };
+
+}  // namespace biopass
 
 #endif  // FACE_REG_H

--- a/auth/pam/helper.cc
+++ b/auth/pam/helper.cc
@@ -1,4 +1,3 @@
-#include <pwd.h>
 #include <spdlog/sinks/ansicolor_sink.h>
 #include <spdlog/spdlog.h>
 #include <stdio.h>
@@ -19,6 +18,9 @@
 #include "fingerprint_auth.h"
 #include "image_utils.h"
 #include "stb_image_write.h"
+
+using biopass::Detection;
+using biopass::FaceDetection;
 
 namespace {
 
@@ -87,7 +89,7 @@ int previewSession(const std::string& cameraPath, const std::string& modelPath, 
     deviceOpt = cameraPath;
   }
 
-  // Silence openpnp-capture's frame-size warnings while we set up.
+  // Silence libcamera's info-level setup noise while we set up.
   spdlog::set_level(spdlog::level::err);
   auto session = biopass::openCameraSession(deviceOpt);
   spdlog::set_level(spdlog::level::info);
@@ -169,8 +171,8 @@ int captureAndCropFace(const std::string& cameraPath, const std::string& outputP
     deviceOpt = cameraPath;
   }
 
-  // Suppress openpnp-capture's noisy "queryFrameSize returned non-discrete..."
-  // warnings during enumeration; errors still propagate.
+  // Silence libcamera's info-level setup noise during enumeration; errors
+  // still propagate.
   spdlog::set_level(spdlog::level::err);
   ImageRGB image = biopass::captureImage(deviceOpt);
   spdlog::set_level(spdlog::level::info);
@@ -268,22 +270,6 @@ int authenticate(const std::string& username, const std::string& service) {
   }
 }
 
-int migrateConfig(const std::string& username) {
-  if (getpwnam(username.c_str()) == nullptr) {
-    spdlog::error("User '{}' not found", username);
-    return 1;
-  }
-
-  std::string error;
-  if (!biopass::migrateConfigSchema(username, &error)) {
-    spdlog::error("Failed to migrate config schema: {}", error);
-    return 1;
-  }
-
-  spdlog::info("Biopass: Config migration completed for user '{}'", username);
-  return 0;
-}
-
 int main(int argc, char** argv) {
   CLI::App app{"Biopass Helper Tool"};
   app.require_subcommand(1, 1);
@@ -320,12 +306,6 @@ int main(int argc, char** argv) {
   auth_cmd->add_option("--username,-u", username, "Username for authentication")->required();
   auth_cmd->add_option("--service,-s", pamService, "PAM service name");
 
-  std::string migrateUsername;
-  auto migrate_cmd = app.add_subcommand(
-      "migrate", "Migration tool for applying schema changes (run once after updates)");
-  migrate_cmd->add_option("--username,-u", migrateUsername, "Username to migrate")->required();
-  migrate_cmd->group("");
-
   try {
     app.parse(argc, argv);
   } catch (const CLI::ParseError& e) {
@@ -350,14 +330,6 @@ int main(int argc, char** argv) {
       return 2;  // PAM_IGNORE logic / error
     }
     return authenticate(username, pamService);
-  }
-
-  if (app.got_subcommand(migrate_cmd)) {
-    if (migrateUsername.empty()) {
-      spdlog::info("{}", app.help());
-      return 1;
-    }
-    return migrateConfig(migrateUsername);
   }
 
   spdlog::error("No valid subcommand provided");

--- a/auth/test/camera/CMakeLists.txt
+++ b/auth/test/camera/CMakeLists.txt
@@ -3,7 +3,7 @@ set(CAMERA_TEST camera_capture_test)
 add_executable(${CAMERA_TEST} main.cpp)
 
 target_link_libraries(${CAMERA_TEST} PRIVATE
+    biopass_face_common
     biopass_stb
-    openpnp-capture
     CLI11::CLI11
 )

--- a/auth/test/camera/main.cpp
+++ b/auth/test/camera/main.cpp
@@ -1,569 +1,151 @@
 #include <CLI/CLI.hpp>
-#include <openpnp-capture.h>
 
 #include <algorithm>
 #include <cctype>
-#include <chrono>
-#include <cstdint>
-#include <cstring>
-#include <cerrno>
-#include <cstdio>
 #include <filesystem>
 #include <iostream>
 #include <optional>
+#include <spdlog/sinks/stdout_color_sinks.h>
+#include <spdlog/spdlog.h>
 #include <stdexcept>
 #include <string>
-#include <thread>
 #include <vector>
 
-#ifdef __linux__
-#include <fcntl.h>
-#include <linux/videodev2.h>
-#include <poll.h>
-#include <sys/mman.h>
-#include <sys/ioctl.h>
-#include <unistd.h>
-#endif
-
+#include "camera_capture.h"
 #include "image_utils.h"
 
 namespace {
 
-struct CaptureDeviceInfo {
-  CapDeviceID index;
-  std::string name;
-  std::string unique_id;
-};
-
-enum class CaptureBackend {
-  OpenPnp,
-#ifdef __linux__
-  V4L2Grey,
-#endif
-};
-
-std::string fourcc_to_string(uint32_t fourcc) {
-  char text[5];
-  text[0] = static_cast<char>(fourcc & 0xff);
-  text[1] = static_cast<char>((fourcc >> 8) & 0xff);
-  text[2] = static_cast<char>((fourcc >> 16) & 0xff);
-  text[3] = static_cast<char>((fourcc >> 24) & 0xff);
-  text[4] = '\0';
-
-  for (int i = 0; i < 4; ++i) {
-    if (text[i] == '\0' || !std::isprint(static_cast<unsigned char>(text[i]))) {
-      text[i] = '.';
-    }
-  }
-
-  return text;
-}
-
-std::vector<CaptureDeviceInfo> enumerate_devices(CapContext ctx) {
-  std::vector<CaptureDeviceInfo> devices;
-  const uint32_t count = Cap_getDeviceCount(ctx);
-  devices.reserve(count);
-  for (uint32_t index = 0; index < count; ++index) {
-    const char *name = Cap_getDeviceName(ctx, index);
-    const char *unique_id = Cap_getDeviceUniqueID(ctx, index);
-    devices.push_back({
-        index,
-        name ? name : "",
-        unique_id ? unique_id : "",
-    });
-  }
-  return devices;
-}
-
-bool is_openpnp_supported_fourcc(uint32_t fourcc) {
-#ifdef __linux__
-  return fourcc == V4L2_PIX_FMT_RGB24 || fourcc == V4L2_PIX_FMT_YUYV || fourcc == V4L2_PIX_FMT_NV12 ||
-         fourcc == V4L2_PIX_FMT_MJPEG;
-#else
-  return true;
-#endif
-}
-
-const char *backend_name(CaptureBackend backend) {
-  switch (backend) {
-    case CaptureBackend::OpenPnp:
-      return "openpnp";
-#ifdef __linux__
-    case CaptureBackend::V4L2Grey:
-      return "v4l2-grey-fallback";
-#endif
-  }
-
-  return "unknown";
-}
-
-#ifdef __linux__
-std::vector<std::string> enumerate_linux_video_capture_paths() {
-  std::vector<std::string> paths;
-  constexpr uint32_t kMaxDevices = 64;
-
-  for (uint32_t index = 0; index < kMaxDevices; ++index) {
-    char device_path[32];
-    std::snprintf(device_path, sizeof(device_path), "/dev/video%u", index);
-
-    const int fd = ::open(device_path, O_RDWR | O_NONBLOCK);
-    if (fd == -1) {
-      continue;
-    }
-
-    v4l2_capability video_cap {};
-    if (::ioctl(fd, VIDIOC_QUERYCAP, &video_cap) == 0 &&
-        (video_cap.device_caps & V4L2_CAP_VIDEO_CAPTURE) != 0) {
-      paths.emplace_back(device_path);
-    }
-
-    ::close(fd);
-  }
-
-  return paths;
-}
-
-std::optional<CapDeviceID> resolve_linux_device_path(const std::string &device_path) {
-  const auto paths = enumerate_linux_video_capture_paths();
-  for (size_t index = 0; index < paths.size(); ++index) {
-    if (paths[index] == device_path) {
-      return static_cast<CapDeviceID>(index);
-    }
-  }
-  return std::nullopt;
-}
-
-std::optional<std::string> linux_device_path_from_index(CapDeviceID device_index) {
-  const auto paths = enumerate_linux_video_capture_paths();
-  if (device_index >= paths.size()) {
-    return std::nullopt;
-  }
-  return paths[device_index];
-}
-
-int xioctl_retry(int fd, unsigned long request, void *arg) {
-  int rc = 0;
-  do {
-    rc = ::ioctl(fd, request, arg);
-  } while (rc == -1 && errno == EINTR);
-  return rc;
-}
-#endif
-
-bool is_unsigned_number(const std::string &value) {
+bool is_unsigned_number(const std::string& value) {
   return !value.empty() &&
-         std::all_of(value.begin(), value.end(),
-                     [](unsigned char ch) { return std::isdigit(ch) != 0; });
+         std::all_of(value.begin(), value.end(), [](unsigned char ch) { return std::isdigit(ch) != 0; });
 }
 
-void print_devices(CapContext ctx) {
-  const auto devices = enumerate_devices(ctx);
-#ifdef __linux__
-  const auto linux_paths = enumerate_linux_video_capture_paths();
-#endif
-
+void print_devices(const std::vector<biopass::CameraDeviceInfo>& devices) {
   if (devices.empty()) {
     std::cout << "No capture devices found.\n";
     return;
   }
 
   std::cout << "Available devices:\n";
-  for (const auto &device : devices) {
-    std::cout << "  [" << device.index << "] " << device.name << '\n';
-    std::cout << "      unique id: " << device.unique_id << '\n';
-#ifdef __linux__
-    if (device.index < linux_paths.size()) {
-      std::cout << "      linux path: " << linux_paths[device.index] << '\n';
+  for (size_t index = 0; index < devices.size(); ++index) {
+    const auto& device = devices[index];
+    std::cout << "  [" << index << "] " << device.model << '\n';
+    std::cout << "      id: " << device.id << '\n';
+    for (const auto& path : device.video_paths) {
+      std::cout << "      linux path: " << path << '\n';
     }
-#endif
   }
 }
 
-void print_formats(CapContext ctx, CapDeviceID device_index) {
-  const int32_t format_count = Cap_getNumFormats(ctx, device_index);
-  if (format_count <= 0) {
-    std::cout << "No formats reported for device " << device_index << ".\n";
+void print_formats(const std::string& device_path) {
+  const auto formats = biopass::listCameraFormats(device_path);
+  if (formats.empty()) {
+    std::cout << "No formats reported for device " << device_path << ".\n";
     return;
   }
 
-  std::cout << "Available formats for device " << device_index << ":\n";
-  for (int32_t format_index = 0; format_index < format_count; ++format_index) {
-    CapFormatInfo format {};
-    if (Cap_getFormatInfo(ctx, device_index, static_cast<CapFormatID>(format_index), &format) !=
-        CAPRESULT_OK) {
-      continue;
+  std::cout << "Available formats for " << device_path << ":\n";
+  for (const auto& format : formats) {
+    std::cout << "  " << format.pixel_format << " supported=" << (format.supported ? "yes" : "no")
+              << " sizes=";
+    for (size_t i = 0; i < format.sizes.size(); ++i) {
+      if (i > 0) {
+        std::cout << ", ";
+      }
+      std::cout << format.sizes[i].first << 'x' << format.sizes[i].second;
     }
-
-    const char *format_backend = nullptr;
-    if (is_openpnp_supported_fourcc(format.fourcc)) {
-      format_backend = "openpnp";
-    }
-#ifdef __linux__
-    else if (format.fourcc == V4L2_PIX_FMT_GREY) {
-      format_backend = "v4l2-grey-fallback";
-    }
-#endif
-    else {
-      format_backend = "unsupported";
-    }
-
-    std::cout << "  [" << format_index << "] " << format.width << 'x' << format.height
-              << " fourcc=" << fourcc_to_string(format.fourcc) << " fps=" << format.fps
-              << " backend=" << format_backend << '\n';
+    std::cout << '\n';
   }
 }
 
-CapFormatInfo get_format_info_or_throw(CapContext ctx, CapDeviceID device_index,
-                                       CapFormatID format_index) {
-  CapFormatInfo format {};
-  if (Cap_getFormatInfo(ctx, device_index, format_index, &format) != CAPRESULT_OK) {
-    throw std::runtime_error("Failed to query format " + std::to_string(format_index) +
-                             " for device " + std::to_string(device_index));
-  }
-  return format;
-}
-
-CapFormatID choose_format(CapContext ctx, CapDeviceID device_index, std::optional<uint32_t> requested) {
-  const int32_t format_count = Cap_getNumFormats(ctx, device_index);
-  if (format_count <= 0) {
-    throw std::runtime_error("No formats reported for device " + std::to_string(device_index));
+// Resolves a device selector to a /dev/video* path. Accepts a Linux path
+// directly, a bare index into listCameraDevices(), or a model substring.
+std::string resolve_device_selector(const std::string& selector) {
+  if (selector.rfind("/dev/video", 0) == 0) {
+    return selector;
   }
 
-  if (requested.has_value()) {
-    if (*requested >= static_cast<uint32_t>(format_count)) {
-      throw std::runtime_error("Format index out of range: " + std::to_string(*requested));
-    }
-    return *requested;
-  }
-
-  for (int32_t format_index = 0; format_index < format_count; ++format_index) {
-    const CapFormatInfo format =
-        get_format_info_or_throw(ctx, device_index, static_cast<CapFormatID>(format_index));
-    if (is_openpnp_supported_fourcc(format.fourcc)) {
-      return static_cast<CapFormatID>(format_index);
-    }
-#ifdef __linux__
-    if (format.fourcc == V4L2_PIX_FMT_GREY) {
-      return static_cast<CapFormatID>(format_index);
-    }
-#endif
-  }
-
-  return 0;
-}
-
-CapDeviceID resolve_device_selector(CapContext ctx, const std::string &selector) {
-  const auto devices = enumerate_devices(ctx);
+  const auto devices = biopass::listCameraDevices();
   if (devices.empty()) {
     throw std::runtime_error("No capture devices found.");
   }
 
   if (is_unsigned_number(selector)) {
-    const auto parsed = static_cast<uint32_t>(std::stoul(selector));
+    const auto parsed = static_cast<size_t>(std::stoul(selector));
     if (parsed >= devices.size()) {
       throw std::runtime_error("Device index out of range: " + selector);
     }
-    return parsed;
+    if (devices[parsed].video_paths.empty()) {
+      throw std::runtime_error("Device [" + selector + "] has no /dev/video* path");
+    }
+    return devices[parsed].video_paths.front();
   }
 
-#ifdef __linux__
-  if (selector.rfind("/dev/video", 0) == 0) {
-    const auto resolved = resolve_linux_device_path(selector);
-    if (!resolved.has_value()) {
-      throw std::runtime_error("No capture device matches path " + selector);
-    }
-    if (*resolved >= devices.size()) {
-      throw std::runtime_error("Resolved device path is outside the OpenPnP device range: " +
-                               selector);
-    }
-    return *resolved;
-  }
-#endif
-
-  for (const auto &device : devices) {
-    if (selector == device.unique_id || selector == device.name) {
-      return device.index;
+  std::vector<std::string> matches;
+  for (const auto& device : devices) {
+    if (device.id.find(selector) != std::string::npos || device.model.find(selector) != std::string::npos) {
+      if (!device.video_paths.empty()) {
+        matches.push_back(device.video_paths.front());
+      }
     }
   }
 
-  std::vector<CapDeviceID> partial_matches;
-  for (const auto &device : devices) {
-    if (device.unique_id.find(selector) != std::string::npos ||
-        device.name.find(selector) != std::string::npos) {
-      partial_matches.push_back(device.index);
-    }
+  if (matches.size() == 1) {
+    return matches.front();
   }
-
-  if (partial_matches.size() == 1) {
-    return partial_matches.front();
-  }
-
-  if (partial_matches.size() > 1) {
+  if (matches.size() > 1) {
     throw std::runtime_error("Device selector is ambiguous: " + selector);
   }
-
   throw std::runtime_error("No device matches selector: " + selector);
 }
 
-ImageRGB capture_frame(CapContext ctx, CapDeviceID device_index, CapFormatID format_index,
-                       int warmup_frames, int attempts, std::chrono::milliseconds poll_interval) {
-  const CapFormatInfo format = get_format_info_or_throw(ctx, device_index, format_index);
-
-  const CapStream stream = Cap_openStream(ctx, device_index, format_index);
-  if (stream < 0 || !Cap_isOpenStream(ctx, stream)) {
-    throw std::runtime_error("Failed to open capture stream for device " +
-                             std::to_string(device_index) + " format " +
-                             std::to_string(format_index));
-  }
-
-  struct StreamCloser {
-    CapContext ctx;
-    CapStream stream;
-    ~StreamCloser() { Cap_closeStream(ctx, stream); }
-  } stream_closer {ctx, stream};
-
-  std::vector<uint8_t> buffer(format.width * format.height * 3);
-
-  int warmed = 0;
-  for (int attempt = 0; attempt < attempts && warmed < warmup_frames; ++attempt) {
-    if (Cap_hasNewFrame(ctx, stream)) {
-      if (Cap_captureFrame(ctx, stream, buffer.data(), buffer.size()) == CAPRESULT_OK) {
-        ++warmed;
-      }
-    } else {
-      std::this_thread::sleep_for(poll_interval);
-    }
-  }
-
-  for (int attempt = 0; attempt < attempts; ++attempt) {
-    if (Cap_hasNewFrame(ctx, stream)) {
-      if (Cap_captureFrame(ctx, stream, buffer.data(), buffer.size()) == CAPRESULT_OK) {
-        return ImageRGB(static_cast<int>(format.width), static_cast<int>(format.height),
-                        buffer.data());
-      }
-    } else {
-      std::this_thread::sleep_for(poll_interval);
-    }
-  }
-
-  throw std::runtime_error("Timed out while waiting for a frame from device " +
-                           std::to_string(device_index));
-}
-
-#ifdef __linux__
-ImageRGB capture_frame_v4l2_grey(const std::string &device_path, const CapFormatInfo &format,
-                                 int warmup_frames, int attempts,
-                                 std::chrono::milliseconds poll_interval) {
-  if (format.fourcc != V4L2_PIX_FMT_GREY) {
-    throw std::runtime_error("V4L2 grey fallback only supports GREY format.");
-  }
-
-  const int fd = ::open(device_path.c_str(), O_RDWR | O_NONBLOCK);
-  if (fd == -1) {
-    throw std::runtime_error("Failed to open " + device_path + ": " + std::strerror(errno));
-  }
-
-  struct FileCloser {
-    int fd;
-    ~FileCloser() {
-      if (fd >= 0) {
-        ::close(fd);
-      }
-    }
-  } file_closer {fd};
-
-  v4l2_format v4l2_format_info {};
-  v4l2_format_info.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
-  v4l2_format_info.fmt.pix.width = format.width;
-  v4l2_format_info.fmt.pix.height = format.height;
-  v4l2_format_info.fmt.pix.pixelformat = format.fourcc;
-  v4l2_format_info.fmt.pix.field = V4L2_FIELD_NONE;
-  if (xioctl_retry(fd, VIDIOC_S_FMT, &v4l2_format_info) == -1) {
-    throw std::runtime_error("VIDIOC_S_FMT failed for " + device_path + ": " +
-                             std::strerror(errno));
-  }
-
-  if (format.fps > 0) {
-    v4l2_streamparm stream_params {};
-    stream_params.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
-    stream_params.parm.capture.timeperframe.numerator = 1;
-    stream_params.parm.capture.timeperframe.denominator = format.fps;
-    xioctl_retry(fd, VIDIOC_S_PARM, &stream_params);
-  }
-
-  v4l2_requestbuffers request_buffers {};
-  request_buffers.count = 4;
-  request_buffers.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
-  request_buffers.memory = V4L2_MEMORY_MMAP;
-  if (xioctl_retry(fd, VIDIOC_REQBUFS, &request_buffers) == -1) {
-    throw std::runtime_error("VIDIOC_REQBUFS failed for " + device_path + ": " +
-                             std::strerror(errno));
-  }
-  if (request_buffers.count == 0) {
-    throw std::runtime_error("No V4L2 buffers were allocated for " + device_path);
-  }
-
-  struct MappedBuffer {
-    void *start = MAP_FAILED;
-    size_t length = 0;
-  };
-  std::vector<MappedBuffer> buffers(request_buffers.count);
-
-  for (uint32_t index = 0; index < request_buffers.count; ++index) {
-    v4l2_buffer buffer {};
-    buffer.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
-    buffer.memory = V4L2_MEMORY_MMAP;
-    buffer.index = index;
-    if (xioctl_retry(fd, VIDIOC_QUERYBUF, &buffer) == -1) {
-      throw std::runtime_error("VIDIOC_QUERYBUF failed for " + device_path + ": " +
-                               std::strerror(errno));
-    }
-
-    buffers[index].length = buffer.length;
-    buffers[index].start = ::mmap(nullptr, buffer.length, PROT_READ | PROT_WRITE, MAP_SHARED, fd,
-                                  buffer.m.offset);
-    if (buffers[index].start == MAP_FAILED) {
-      throw std::runtime_error("mmap failed for " + device_path + ": " + std::strerror(errno));
-    }
-  }
-
-  struct BufferUnmapper {
-    std::vector<MappedBuffer> &buffers;
-    ~BufferUnmapper() {
-      for (const auto &buffer : buffers) {
-        if (buffer.start != MAP_FAILED) {
-          ::munmap(buffer.start, buffer.length);
-        }
-      }
-    }
-  } buffer_unmapper {buffers};
-
-  for (uint32_t index = 0; index < request_buffers.count; ++index) {
-    v4l2_buffer buffer {};
-    buffer.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
-    buffer.memory = V4L2_MEMORY_MMAP;
-    buffer.index = index;
-    if (xioctl_retry(fd, VIDIOC_QBUF, &buffer) == -1) {
-      throw std::runtime_error("VIDIOC_QBUF failed for " + device_path + ": " +
-                               std::strerror(errno));
-    }
-  }
-
-  v4l2_buf_type buffer_type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
-  if (xioctl_retry(fd, VIDIOC_STREAMON, &buffer_type) == -1) {
-    throw std::runtime_error("VIDIOC_STREAMON failed for " + device_path + ": " +
-                             std::strerror(errno));
-  }
-
-  struct StreamStopper {
-    int fd;
-    v4l2_buf_type type;
-    ~StreamStopper() { xioctl_retry(fd, VIDIOC_STREAMOFF, &type); }
-  } stream_stopper {fd, buffer_type};
-
-  ImageRGB image(static_cast<int>(v4l2_format_info.fmt.pix.width),
-                 static_cast<int>(v4l2_format_info.fmt.pix.height));
-  const uint32_t bytes_per_line =
-      std::max<uint32_t>(v4l2_format_info.fmt.pix.bytesperline, v4l2_format_info.fmt.pix.width);
-  const int total_frames_needed = std::max(0, warmup_frames) + 1;
-  int captured_frames = 0;
-
-  for (int attempt = 0; attempt < attempts; ++attempt) {
-    pollfd poll_info {};
-    poll_info.fd = fd;
-    poll_info.events = POLLIN;
-    const int poll_rc = ::poll(&poll_info, 1, static_cast<int>(poll_interval.count()));
-    if (poll_rc == -1) {
-      if (errno == EINTR) {
-        continue;
-      }
-      throw std::runtime_error("poll failed for " + device_path + ": " + std::strerror(errno));
-    }
-    if (poll_rc == 0) {
-      continue;
-    }
-
-    v4l2_buffer buffer {};
-    buffer.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
-    buffer.memory = V4L2_MEMORY_MMAP;
-    if (xioctl_retry(fd, VIDIOC_DQBUF, &buffer) == -1) {
-      if (errno == EAGAIN) {
-        continue;
-      }
-      throw std::runtime_error("VIDIOC_DQBUF failed for " + device_path + ": " +
-                               std::strerror(errno));
-    }
-
-    const uint8_t *grey =
-        static_cast<const uint8_t *>(buffers.at(buffer.index).start);
-    ++captured_frames;
-    if (captured_frames >= total_frames_needed) {
-      for (uint32_t y = 0; y < v4l2_format_info.fmt.pix.height; ++y) {
-        const uint8_t *src_row = grey + y * bytes_per_line;
-        uint8_t *dst_row = image.ptr() + y * v4l2_format_info.fmt.pix.width * 3;
-        for (uint32_t x = 0; x < v4l2_format_info.fmt.pix.width; ++x) {
-          const uint8_t value = src_row[x];
-          dst_row[x * 3 + 0] = value;
-          dst_row[x * 3 + 1] = value;
-          dst_row[x * 3 + 2] = value;
-        }
-      }
-
-      if (xioctl_retry(fd, VIDIOC_QBUF, &buffer) == -1) {
-        throw std::runtime_error("VIDIOC_QBUF failed for " + device_path + ": " +
-                                 std::strerror(errno));
-      }
-      return image;
-    }
-
-    if (xioctl_retry(fd, VIDIOC_QBUF, &buffer) == -1) {
-      throw std::runtime_error("VIDIOC_QBUF failed for " + device_path + ": " +
-                               std::strerror(errno));
-    }
-  }
-
-  throw std::runtime_error("Timed out while waiting for a GREY frame from " + device_path);
-}
-#endif
-
 }  // namespace
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   namespace fs = std::filesystem;
 
-  CLI::App app("Capture a single image frame from a camera with OpenPnP Capture.");
+  spdlog::set_default_logger(spdlog::stderr_color_mt("camera_capture_test"));
+  spdlog::set_level(spdlog::level::debug);
+
+  CLI::App app("Capture a single image frame from a camera via libcamera.");
 
   std::string device_selector;
   std::string output_path = "capture.jpg";
-  uint32_t format_index = 0;
+  bool grey = false;
   int warmup_frames = 5;
-  int attempts = 1000;
+  int timeout_ms = 10000;
+  // Deprecated aliases retained so existing field scripts keep working.
+  int attempts = 0;
   int poll_interval_ms = 10;
   bool list_devices = false;
   bool list_formats = false;
 
   app.add_option("device", device_selector,
-                 "Device selector. Accepts an OpenPnP device index, name, unique id, or a "
-                 "Linux path like /dev/video0.");
+                 "Device selector. Accepts a Linux path like /dev/video0, a device index, or a "
+                 "model substring.");
   app.add_flag("--list-devices", list_devices, "List available capture devices and exit.");
-  app.add_flag("--list-formats", list_formats,
-               "List available formats for the selected device and exit.");
-  app.add_option("-o,--output", output_path, "Output image path.")
-      ->default_val(output_path);
-  auto *format_option = app.add_option("-f,--format", format_index,
-                                       "OpenPnP format index to capture with.")
-      ->default_val(format_index);
+  app.add_flag("--list-formats", list_formats, "List available formats for the selected device and exit.");
+  app.add_option("-o,--output", output_path, "Output image path.")->default_val(output_path);
+  app.add_flag("--grey", grey, "Capture from the camera's GREY/R8 stream (IR cameras).");
   app.add_option("--warmup-frames", warmup_frames, "Frames to discard before capture.")
       ->default_val(warmup_frames);
-  app.add_option("--attempts", attempts, "Polling attempts before giving up.")
-      ->default_val(attempts);
-  app.add_option("--poll-interval-ms", poll_interval_ms, "Sleep between frame polls.")
+  app.add_option("--timeout-ms", timeout_ms, "Capture deadline in milliseconds.")
+      ->default_val(timeout_ms);
+  app.add_option("--attempts", attempts,
+                 "Deprecated: computes --timeout-ms as attempts * --poll-interval-ms.");
+  app.add_option("--poll-interval-ms", poll_interval_ms,
+                 "Deprecated: used only together with --attempts.")
       ->default_val(poll_interval_ms);
 
   try {
     app.parse(argc, argv);
-  } catch (const CLI::ParseError &e) {
+  } catch (const CLI::ParseError& e) {
     return app.exit(e);
+  }
+
+  if (attempts > 0) {
+    timeout_ms = attempts * poll_interval_ms;
   }
 
   if (!list_devices && device_selector.empty()) {
@@ -571,81 +153,32 @@ int main(int argc, char **argv) {
     return 1;
   }
 
-  CapContext ctx = Cap_createContext();
-  if (!ctx) {
-    std::cerr << "Failed to create OpenPnP capture context.\n";
-    return 1;
-  }
-
-  struct ContextCloser {
-    CapContext ctx;
-    ~ContextCloser() { Cap_releaseContext(ctx); }
-  } context_closer {ctx};
-
   try {
     if (list_devices) {
-      print_devices(ctx);
+      print_devices(biopass::listCameraDevices());
       if (device_selector.empty()) {
         return 0;
       }
     }
 
-    const CapDeviceID device_index = resolve_device_selector(ctx, device_selector);
-    const auto devices = enumerate_devices(ctx);
-    const auto &device = devices.at(device_index);
-    const CapFormatID selected_format =
-        choose_format(ctx, device_index,
-                      format_option->count() > 0 ? std::optional<uint32_t>(format_index)
-                                                 : std::nullopt);
-    const CapFormatInfo format = get_format_info_or_throw(ctx, device_index, selected_format);
+    const std::string device_path = resolve_device_selector(device_selector);
 
     if (list_formats) {
-      std::cout << "Device [" << device.index << "] " << device.name << '\n';
-      print_formats(ctx, device_index);
+      print_formats(device_path);
       return 0;
     }
 
-    CaptureBackend backend = CaptureBackend::OpenPnp;
-#ifdef __linux__
-    std::optional<std::string> linux_device_path;
-    if (device_selector.rfind("/dev/video", 0) == 0) {
-      linux_device_path = device_selector;
-    } else {
-      linux_device_path = linux_device_path_from_index(device_index);
-    }
-
-    if (!is_openpnp_supported_fourcc(format.fourcc)) {
-      if (format.fourcc == V4L2_PIX_FMT_GREY && linux_device_path.has_value()) {
-        backend = CaptureBackend::V4L2Grey;
-      } else {
-        throw std::runtime_error("Format " + fourcc_to_string(format.fourcc) +
-                                 " is not supported by openpnp-capture on Linux.");
-      }
-    }
-#else
-    if (!is_openpnp_supported_fourcc(format.fourcc)) {
-      throw std::runtime_error("Selected format is not supported by openpnp-capture.");
-    }
-#endif
-
-    std::cout << "Capturing from device [" << device.index << "] " << device.name
-              << " using format [" << selected_format << "] " << format.width << 'x'
-              << format.height << " fourcc=" << fourcc_to_string(format.fourcc)
-              << " backend=" << backend_name(backend) << '\n';
+    const auto format = grey ? biopass::CameraCaptureFormat::V4L2Grey : biopass::CameraCaptureFormat::Default;
+    std::cout << "Capturing from " << device_path << " (grey=" << (grey ? "yes" : "no") << ")\n";
     std::cout.flush();
 
-    ImageRGB image;
-    if (backend == CaptureBackend::OpenPnp) {
-      image = capture_frame(ctx, device_index, selected_format, warmup_frames, attempts,
-                            std::chrono::milliseconds(poll_interval_ms));
+    auto session = biopass::openCameraSession(device_path, format, warmup_frames, timeout_ms);
+    if (!session) {
+      std::cerr << "Failed to open camera session for " << device_path << '\n';
+      return 1;
     }
-#ifdef __linux__
-    else if (backend == CaptureBackend::V4L2Grey) {
-      image = capture_frame_v4l2_grey(*linux_device_path, format, warmup_frames, attempts,
-                                      std::chrono::milliseconds(poll_interval_ms));
-    }
-#endif
 
+    const ImageRGB image = session->capture();
     if (image.empty()) {
       std::cerr << "Capture returned an empty image.\n";
       return 1;
@@ -662,10 +195,9 @@ int main(int argc, char **argv) {
       return 1;
     }
 
-    std::cout << "Captured " << image.width << 'x' << image.height << " from device ["
-              << device.index << "] " << device.name << '\n';
+    std::cout << "Captured " << image.width << 'x' << image.height << " from " << device_path << '\n';
     std::cout << "Saved image to " << absolute_output_path << '\n';
-  } catch (const std::exception &e) {
+  } catch (const std::exception& e) {
     std::cerr << e.what() << '\n';
     return 1;
   }

--- a/auth/test/face_engine/CMakeLists.txt
+++ b/auth/test/face_engine/CMakeLists.txt
@@ -11,6 +11,7 @@ target_link_libraries(${FACE_TEST} PRIVATE
     biopass_det
     biopass_reg
     biopass_stb
+    biopass_onnx
     CLI11::CLI11
 )
 

--- a/auth/test/face_engine/README.md
+++ b/auth/test/face_engine/README.md
@@ -1,7 +1,7 @@
 # Face Engine in Face Pass
 ## Preparation
 
-Dependencies (ONNX Runtime and openpnp-capture) are automatically fetched via CMake FetchContent. No manual installation required.
+ONNX Runtime is automatically fetched via CMake FetchContent. Camera capture uses the system libcamera and libjpeg-turbo packages (`libcamera-dev`, `libturbojpeg0-dev`) found via pkg-config — install them before configuring.
 
 ## Build
 ```bash

--- a/auth/test/face_engine/main.cpp
+++ b/auth/test/face_engine/main.cpp
@@ -9,6 +9,11 @@
 #include "face_recognition.h"
 #include "image_utils.h"
 
+using biopass::Detection;
+using biopass::FaceDetection;
+using biopass::FaceRecognition;
+using biopass::MatchResult;
+
 namespace {
 
 std::string default_model_dir() {

--- a/docs/IR camera.md
+++ b/docs/IR camera.md
@@ -26,6 +26,8 @@ v4l2-ctl --list-devices
 
 Look for the device node that belongs to your IR sensor, for example `/dev/video2`.
 
+Biopass captures through libcamera; you can also identify devices with `cam -l` (from `libcamera-tools`) or the bundled `camera_capture_test --list-devices` / `--list-formats /dev/videoN` debug tool.
+
 ## 2. Enable It In Biopass
 
 Open the Biopass desktop app and go to the face settings.
@@ -64,3 +66,11 @@ sudo systemctl enable --now linux-enable-ir-emitter
 ```
 
 Thanks @notherealmarco for help me on this https://github.com/TickLabVN/biopass/discussions/60#discussioncomment-16521628.
+
+## 4. If The IR Presence Check Fails Intermittently
+
+Some IR emitters blink rapidly, so an individual captured frame can be over-exposed
+(all-white) or under-exposed (all-dark) and yield no detectable face. Biopass retries
+the IR presence check (capture + detection) for up to `anti_spoofing.ir_presence_timeout_ms`
+milliseconds (default `1500`) in `config.yaml` before giving up, so a single bad frame
+should no longer fail the check. If failures persist, try increasing this value.


### PR DESCRIPTION
As mentioned in #55 and #56, some modern cameras are not compatible. This PR is to migrate from `openpnp-capture` to `libcamera`, which is a wider adopted camera library and support modern devices.
