### PR TITLE
fix(polkit integration): infinite loop occur when debug log is on

### DIFF
--- a/auth/core/auth_config.cc
+++ b/auth/core/auth_config.cc
@@ -6,6 +6,7 @@
 #include <yaml-cpp/yaml.h>
 
 #include <algorithm>
+#include <cstring>
 #include <fstream>
 
 namespace biopass {
@@ -208,13 +209,13 @@ static int mkdir_p(const std::string& path) {
       continue;
     ret = mkdir(dir.c_str(), 0777);
     if (ret == -1 && errno != EEXIST) {
-      perror("Failed to create directory");
+      spdlog::error("Biopass: Failed to create directory '{}': {}", dir, strerror(errno));
       return 1;
     }
   }
   ret = mkdir(path.c_str(), 0777);
   if (ret == -1 && errno != EEXIST) {
-    perror("Failed to create directory");
+    spdlog::error("Biopass: Failed to create directory '{}': {}", path, strerror(errno));
     return 1;
   }
   return 0;
@@ -252,11 +253,40 @@ std::string getDebugPath(const std::string& username) {
   return user_data_dir(username) + "/debugs";
 }
 
+std::string getLogPath(const std::string& username) { return user_data_dir(username) + "/logs"; }
+
+void fixOwnership(const std::string& path, const std::string& username) {
+  if (geteuid() != 0) {
+    return;
+  }
+  struct passwd* pw = getpwnam(username.c_str());
+  if (pw == nullptr) {
+    return;
+  }
+  if (chown(path.c_str(), pw->pw_uid, pw->pw_gid) != 0) {
+    spdlog::error("Biopass: Failed to chown '{}' to {}: {}", path, username, strerror(errno));
+  }
+}
+
 int setupConfig(const std::string& username) {
   const std::string dataDir = user_data_dir(username);
   if (mkdir_p(dataDir + "/faces") != 0)
     return 1;
-  return mkdir_p(dataDir + "/debugs");
+  if (mkdir_p(dataDir + "/debugs") != 0)
+    return 1;
+  if (mkdir_p(dataDir + "/logs") != 0)
+    return 1;
+
+  // PAM auth flows run this as root, which leaves freshly created
+  // directories owned by root:root; a later user-invoked run (the desktop
+  // app capturing a preview, or a dev testing biopass-helper directly) then
+  // can't write into them. Hand the whole subtree back to the target user
+  // so root- and user-invoked runs never fight over ownership.
+  fixOwnership(dataDir, username);
+  fixOwnership(dataDir + "/faces", username);
+  fixOwnership(dataDir + "/debugs", username);
+  fixOwnership(dataDir + "/logs", username);
+  return 0;
 }
 
 }  // namespace biopass

--- a/auth/core/auth_config.h
+++ b/auth/core/auth_config.h
@@ -119,6 +119,10 @@ bool configExists(const std::string& username);
 
 std::vector<std::string> listFaces(const std::string& username);
 std::string getDebugPath(const std::string& username);
+std::string getLogPath(const std::string& username);
 int setupConfig(const std::string& username);
+
+// Chowns `path` to `username`'s uid/gid; no-op unless running as root.
+void fixOwnership(const std::string& path, const std::string& username);
 
 }  // namespace biopass

--- a/auth/face/common/camera_capture.cc
+++ b/auth/face/common/camera_capture.cc
@@ -34,8 +34,8 @@ std::string device_label(const std::optional<std::string>& linux_video_device_pa
   return linux_video_device_path.has_value() ? *linux_video_device_path : std::string("<default>");
 }
 
-// Routes libcamera's internal logging through spdlog so it lands in the same
-// /var/log/biopass/<user>/ files the rest of the process writes to.
+// Routes libcamera's internal logging through spdlog so it lands wherever
+// the rest of the process's logs go (see setupBiopassLogger in helper.cc).
 class SpdlogStreambuf : public std::streambuf {
  public:
   int overflow(int ch) override {

--- a/auth/pam/helper.cc
+++ b/auth/pam/helper.cc
@@ -1,4 +1,4 @@
-#include <spdlog/sinks/ansicolor_sink.h>
+#include <spdlog/sinks/basic_file_sink.h>
 #include <spdlog/spdlog.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -6,6 +6,7 @@
 
 #include <CLI/CLI.hpp>
 #include <algorithm>
+#include <ctime>
 #include <iostream>
 #include <memory>
 #include <vector>
@@ -33,6 +34,48 @@ bool encodeJpeg(const ImageRGB& img, int quality, std::vector<uint8_t>& out) {
   out.clear();
   return stbi_write_jpg_to_func(&appendJpegToBuffer, &out, img.width, img.height, 3, img.ptr(),
                                 quality) != 0;
+}
+
+std::string todayDateString() {
+  std::time_t now = std::time(nullptr);
+  std::tm local{};
+  localtime_r(&now, &local);
+  char buf[sizeof("yyyy-mm-dd")];
+  std::strftime(buf, sizeof(buf), "%Y-%m-%d", &local);
+  return std::string(buf);
+}
+
+// This process's stdout/stderr are inherited from whatever spawned the PAM
+// stack, and PAM callers routinely treat those fds as a structured control
+// channel rather than a log stream -- e.g. GNOME Shell's polkit auth agent
+// reads polkit-agent-helper-1's inherited output as a strict line protocol
+// (SUCCESS / FAILURE / PAM_PROMPT_ECHO_OFF ...). biopass-helper is forked
+// from that same process tree, so *any* line it writes there, even a single
+// warning, is garbage to that parser and derails the caller's state machine
+// (observed as GNOME Shell logging "Unknown line ... from helper" and
+// retrying authentication in a tight loop -- `pkexec id` never returning).
+// So: never write to stdout/stderr here, regardless of level. Verbose output
+// only goes to a per-day file, and only when Debug Mode is on.
+void setupBiopassLogger(const std::string& username, bool debug) {
+  std::vector<spdlog::sink_ptr> sinks;
+
+  if (debug) {
+    biopass::setupConfig(username);
+    const std::string log_path = biopass::getLogPath(username) + "/" + todayDateString() + ".log";
+    try {
+      auto file_sink = std::make_shared<spdlog::sinks::basic_file_sink_mt>(log_path,
+                                                                           /*truncate=*/false);
+      sinks.push_back(file_sink);
+      biopass::fixOwnership(log_path, username);
+    } catch (const spdlog::spdlog_ex&) {
+      // Can't log this failure anywhere safe (see above) -- fall through
+      // with no sinks; log calls become no-ops rather than risk stdout/stderr.
+    }
+  }
+
+  auto logger = std::make_shared<spdlog::logger>("biopass", sinks.begin(), sinks.end());
+  spdlog::set_default_logger(logger);
+  spdlog::set_level(debug ? spdlog::level::debug : spdlog::level::off);
 }
 
 }  // namespace
@@ -221,13 +264,7 @@ int authenticate(const std::string& username, const std::string& service) {
     return 2;  // PAM_IGNORE
   }
 
-  auto stderr_sink = std::make_shared<spdlog::sinks::ansicolor_stderr_sink_mt>();
-  spdlog::set_default_logger(std::make_shared<spdlog::logger>("biopass", stderr_sink));
-  if (config.strategy.debug) {
-    spdlog::set_level(spdlog::level::debug);
-  } else {
-    spdlog::set_level(spdlog::level::off);
-  }
+  setupBiopassLogger(pUsername, config.strategy.debug);
 
   biopass::AuthConfig runtime_config;
   runtime_config.debug = config.strategy.debug;

--- a/auth/pam/pam.cc
+++ b/auth/pam/pam.cc
@@ -7,20 +7,20 @@
 #include <unistd.h>
 
 // Called by PAM when a user needs to be authenticated
-PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc, const char **argv) {
+PAM_EXTERN int pam_sm_authenticate(pam_handle_t* pamh, int flags, int argc, const char** argv) {
   (void)flags;
   (void)argc;
   (void)argv;
 
   int retval;
 
-  const char *service = nullptr;
-  retval = pam_get_item(pamh, PAM_SERVICE, (const void **)&service);
+  const char* service = nullptr;
+  retval = pam_get_item(pamh, PAM_SERVICE, (const void**)&service);
   if (retval != PAM_SUCCESS) {
     service = nullptr;
   }
 
-  const char *pUsername;
+  const char* pUsername;
   retval = pam_get_user(pamh, &pUsername, NULL);
   if (retval != PAM_SUCCESS) {
     return retval;
@@ -38,8 +38,11 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc, cons
       execl("/usr/bin/biopass-helper", "biopass-helper", "auth", "--username", pUsername, NULL);
     }
 
-    // If execl returns, it failed
-    perror("execl failed");
+    // If execl returns, it failed. Don't perror() here: this process's
+    // stdio is inherited from the PAM caller (e.g. polkit-agent-helper-1),
+    // which some callers (GNOME Shell's polkit agent) parse as a strict
+    // line protocol -- any unexpected line on it derails the caller's
+    // authentication state machine instead of a clean failure.
     exit(1);
   } else {
     int status;
@@ -62,7 +65,7 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc, cons
 }
 
 // The functions below are required by PAM, but not needed in this module
-PAM_EXTERN int pam_sm_open_session(pam_handle_t *pamh, int flags, int argc, const char **argv) {
+PAM_EXTERN int pam_sm_open_session(pam_handle_t* pamh, int flags, int argc, const char** argv) {
   (void)pamh;
   (void)flags;
   (void)argc;
@@ -70,7 +73,7 @@ PAM_EXTERN int pam_sm_open_session(pam_handle_t *pamh, int flags, int argc, cons
   return PAM_IGNORE;
 }
 
-PAM_EXTERN int pam_sm_acct_mgmt(pam_handle_t *pamh, int flags, int argc, const char **argv) {
+PAM_EXTERN int pam_sm_acct_mgmt(pam_handle_t* pamh, int flags, int argc, const char** argv) {
   (void)pamh;
   (void)flags;
   (void)argc;
@@ -78,7 +81,7 @@ PAM_EXTERN int pam_sm_acct_mgmt(pam_handle_t *pamh, int flags, int argc, const c
   return PAM_IGNORE;
 }
 
-PAM_EXTERN int pam_sm_close_session(pam_handle_t *pamh, int flags, int argc, const char **argv) {
+PAM_EXTERN int pam_sm_close_session(pam_handle_t* pamh, int flags, int argc, const char** argv) {
   (void)pamh;
   (void)flags;
   (void)argc;
@@ -86,7 +89,7 @@ PAM_EXTERN int pam_sm_close_session(pam_handle_t *pamh, int flags, int argc, con
   return PAM_IGNORE;
 }
 
-PAM_EXTERN int pam_sm_chauthtok(pam_handle_t *pamh, int flags, int argc, const char **argv) {
+PAM_EXTERN int pam_sm_chauthtok(pam_handle_t* pamh, int flags, int argc, const char** argv) {
   (void)pamh;
   (void)flags;
   (void)argc;
@@ -94,7 +97,7 @@ PAM_EXTERN int pam_sm_chauthtok(pam_handle_t *pamh, int flags, int argc, const c
   return PAM_IGNORE;
 }
 
-PAM_EXTERN int pam_sm_setcred(pam_handle_t *pamh, int flags, int argc, const char **argv) {
+PAM_EXTERN int pam_sm_setcred(pam_handle_t* pamh, int flags, int argc, const char** argv) {
   (void)pamh;
   (void)flags;
   (void)argc;


### PR DESCRIPTION
## Summary

The auth flow was triggered infinitely when I turn on the debug log flag. The solution is to write logs to rolling logfiles, instead of writing logs to stderr/stdout.
