### PR TITLE
feat: add --version/-v flag to biopass-helper and biopass (+ UI version badge)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,9 @@ build-app: build-auth
 	@echo "==> [app] Pinning model downloader to release $(VERSION)…"
 	sed -i -E 's#^BASE_URL="https://github.com/TickLabVN/biopass/releases/(latest/download|download/[^"]+)"#BASE_URL="https://github.com/TickLabVN/biopass/releases/download/$(VERSION)"#' \
 	    $(APP_DIR)/src-tauri/scripts/download_models.sh
+	@echo "==> [app] Pinning app version to $(VERSION)…"
+	sed -i -E 's/^version = "[^"]*"/version = "$(VERSION)"/' \
+	    $(APP_DIR)/src-tauri/Cargo.toml
 	@echo "==> [app] Building Tauri application…"
 	cd $(APP_DIR) && bun run tauri build
 

--- a/app/src-tauri/src/main.rs
+++ b/app/src-tauri/src/main.rs
@@ -2,5 +2,12 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
+    if std::env::args()
+        .skip(1)
+        .any(|a| a == "--version" || a == "-v")
+    {
+        println!("{}", env!("CARGO_PKG_VERSION"));
+        return;
+    }
     biopass_lib::run()
 }

--- a/app/src/app/__root.tsx
+++ b/app/src/app/__root.tsx
@@ -5,6 +5,7 @@ import {
   useRouterState,
 } from "@tanstack/react-router";
 import { TanStackRouterDevtools } from "@tanstack/react-router-devtools";
+import { getVersion } from "@tauri-apps/api/app";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { Cpu, Laptop, Moon, Settings, Sun, User } from "lucide-react";
 import { useTheme } from "next-themes";
@@ -21,6 +22,7 @@ import {
 
 function App() {
   const [username, setUsername] = useState("");
+  const [version, setVersion] = useState("");
   const { setTheme, theme } = useTheme();
   const pathname = useRouterState({
     select: (state) => state.location.pathname,
@@ -80,8 +82,17 @@ function App() {
       }
     };
 
+    const loadVersion = async () => {
+      try {
+        setVersion(await getVersion());
+      } catch (err) {
+        console.error("Failed to get app version:", err);
+      }
+    };
+
     loadUsername();
     loadInitialTheme();
+    loadVersion();
   }, [setTheme]);
 
   // Update theme in config when it changes manually via toggle
@@ -111,6 +122,11 @@ function App() {
                 <span className="font-bold text-lg hidden sm:inline-block">
                   Biopass
                 </span>
+                {version && (
+                  <span className="text-xs text-muted-foreground">
+                    v{version}
+                  </span>
+                )}
               </div>
 
               <div className="flex items-center gap-2">

--- a/auth/CMakeLists.txt
+++ b/auth/CMakeLists.txt
@@ -1,12 +1,17 @@
 cmake_minimum_required(VERSION 3.22)
-project(biopass)
+# Resolve version from the environment (CI) or -DPROJECT_VERSION (Makefile),
+# before project() clears the variable, otherwise fall back to a default.
 if(DEFINED ENV{PROJECT_VERSION})
-    message(STATUS "Project version: $ENV{PROJECT_VERSION}")
-    set(PROJECT_VERSION $ENV{PROJECT_VERSION})
+    set(BIOPASS_VERSION $ENV{PROJECT_VERSION})
+elseif(PROJECT_VERSION)
+    set(BIOPASS_VERSION ${PROJECT_VERSION})
 else()
-    message(STATUS "Project version: latest")
-    set(PROJECT_VERSION 0.1.0)
+    set(BIOPASS_VERSION 0.1.0)
 endif()
+
+project(biopass)
+set(PROJECT_VERSION ${BIOPASS_VERSION})
+message(STATUS "Project version: ${PROJECT_VERSION}")
 
 # Require C++17
 set(CMAKE_CXX_STANDARD          17)

--- a/auth/pam/CMakeLists.txt
+++ b/auth/pam/CMakeLists.txt
@@ -13,6 +13,10 @@ add_executable(biopass-helper
     helper.cc
 )
 
+target_compile_definitions(biopass-helper PRIVATE
+    BIOPASS_VERSION="${PROJECT_VERSION}"
+)
+
 target_include_directories(biopass-helper PRIVATE
     ${ONNXRUNTIME_INCLUDE_DIRS}
     ${FaceDetection_INCLUDE_DIRS}

--- a/auth/pam/helper.cc
+++ b/auth/pam/helper.cc
@@ -305,6 +305,7 @@ int authenticate(const std::string& username, const std::string& service) {
 
 int main(int argc, char** argv) {
   CLI::App app{"Biopass Helper Tool"};
+  app.set_version_flag("--version,-v", BIOPASS_VERSION);
   app.require_subcommand(1, 1);
 
   auto crop_cmd = app.add_subcommand("crop-face", "Crop a face from an image");


### PR DESCRIPTION
As mentioned in https://github.com/TickLabVN/biopass/issues/109#issuecomment-4967888943 , I think it would be useful to have a `--version` flag

This PR introduces a way to add flags to the startup, and can be extended later.

Adds a `--version`/`-v` flag across both binaries, plus a version badge in the app UI.

**biopass-helper** (`auth/`): CLI11 built-in version flag. `biopass-helper --version` prints the version and exits 0 without needing a subcommand.

**biopass** (`app/`, Tauri): `--version`/`-v` on the Tauri binary prints the version and exits before launching the window. The header also shows the version next to the logo via the `getVersion()` API. No new dependencies (uses `std::env::args`).

**Version wiring**: the Makefile passes the git-derived version, but it was not actually reaching either binary:
- `auth/CMakeLists.txt` only read the environment variable and `project()` cleared it, so the helper defaulted to `0.1.0`. Now resolved before `project()`.
- The Tauri app had no version wiring at all and defaulted to `Cargo.toml`'s `0.1.0`. The Makefile now seds the app `Cargo.toml` version at build time (same pattern as the existing model-downloader step), so both the CLI flag and the UI report the real release (e.g. `1.4.1`).

Verified locally: helper and app both print `1.4.1` when built with the git-tag version; env and `0.1.0` default paths still work; frontend typechecks and lints clean.
