### PR TITLE
Fix KDE Plasma login integration

### DIFF
--- a/auth/BundleLibcamera.cmake
+++ b/auth/BundleLibcamera.cmake
@@ -23,6 +23,7 @@ ExternalProject_Add(libcamera_ext
     GIT_TAG        ${LIBCAMERA_VERSION}
     GIT_SHALLOW    TRUE
     CONFIGURE_COMMAND meson setup --prefix=${LIBCAMERA_STAGING} --libdir=lib --buildtype=release
+        -Dwerror=false
         -Dpipelines=uvcvideo -Dipas=[] -Dgstreamer=disabled -Dv4l2=disabled
         -Dcam=disabled -Dqcam=disabled -Dlc-compliance=disabled
         -Dtracing=disabled -Ddocumentation=disabled -Dpycamera=disabled -Dtest=false -Dudev=enabled

--- a/auth/fingerprint/fingerprint_auth.cc
+++ b/auth/fingerprint/fingerprint_auth.cc
@@ -260,16 +260,45 @@ AuthResult FingerprintAuth::authenticate(const std::string& username, const Auth
                                      // not set up.
   }
 
-  GVariant* claim_ret =
-      g_dbus_proxy_call_sync(device, "Claim", g_variant_new("(s)", username.c_str()),
-                             G_DBUS_CALL_FLAGS_NONE, -1, nullptr, &error);
+  // Retry Claim up to 3 times with backoff if the device is busy.  The
+  // device may already be claimed by the biopass GUI app, another PAM
+  // session, or a PolKit agent.  A short sleep gives the other process
+  // time to release it.
+  GVariant* claim_ret = nullptr;
+  GError* claim_error = nullptr;
+  const int kMaxClaimRetries = 3;
+  for (int attempt = 1; attempt <= kMaxClaimRetries; attempt++) {
+    if (claim_error) {
+      g_error_free(claim_error);
+      claim_error = nullptr;
+    }
+    claim_ret =
+        g_dbus_proxy_call_sync(device, "Claim", g_variant_new("(s)", username.c_str()),
+                               G_DBUS_CALL_FLAGS_NONE, -1, nullptr, &claim_error);
+
+    if (claim_ret) {
+      break;
+    }
+
+    std::string err_msg = claim_error ? claim_error->message : "";
+    spdlog::warn("FingerprintAuth: Failed to claim device (attempt {}/{}): {}",
+                 attempt, kMaxClaimRetries, err_msg);
+
+    if (attempt < kMaxClaimRetries) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(200 * attempt));
+    }
+  }
 
   if (!claim_ret) {
-    spdlog::error("FingerprintAuth: Failed to claim device: {}", (error ? error->message : ""));
-    if (error)
-      g_error_free(error);
+    spdlog::error("FingerprintAuth: Could not claim device after {} retries: {}",
+                  kMaxClaimRetries, (claim_error ? claim_error->message : ""));
+    if (claim_error)
+      g_error_free(claim_error);
     cleanup();
     return AuthResult::Unavailable;
+  }
+  if (claim_error) {
+    g_error_free(claim_error);
   }
   g_variant_unref(claim_ret);
   device_claimed = true;

--- a/auth/pam/helper.cc
+++ b/auth/pam/helper.cc
@@ -1,8 +1,11 @@
 #include <spdlog/sinks/basic_file_sink.h>
 #include <spdlog/spdlog.h>
+#include <grp.h>
+#include <pwd.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 #include <CLI/CLI.hpp>
 #include <algorithm>
@@ -249,6 +252,38 @@ int captureAndCropFace(const std::string& cameraPath, const std::string& outputP
   return 0;
 }
 
+// Drop privileges from root to the target user so that fprintd D-Bus calls
+// use the correct UID for looking up fingerprint templates.  When the helper
+// runs as root (forked from PAM), fprintd's ListEnrolledFingers / VerifyStart
+// use the caller's UID (0) and find no enrolled fingers for root.
+// Must be called after setupConfig() since creating directories needs root.
+static bool drop_to_user(const std::string& username) {
+  if (geteuid() != 0) {
+    return true;  // Not running as root, nothing to do.
+  }
+  struct passwd* pw = getpwnam(username.c_str());
+  if (pw == nullptr) {
+    spdlog::error("Biopass: Cannot drop privileges, unknown user '{}'", username);
+    return false;
+  }
+  // Set supplementary groups first (needs root, done before setuid).
+  if (initgroups(username.c_str(), pw->pw_gid) != 0) {
+    spdlog::error("Biopass: initgroups failed for '{}': {}", username, strerror(errno));
+    return false;
+  }
+  if (setgid(pw->pw_gid) != 0) {
+    spdlog::error("Biopass: setgid failed for '{}': {}", username, strerror(errno));
+    return false;
+  }
+  if (setuid(pw->pw_uid) != 0) {
+    spdlog::error("Biopass: setuid failed for '{}': {}", username, strerror(errno));
+    return false;
+  }
+  spdlog::debug("Biopass: Dropped privileges to {} (uid={}, gid={})",
+                username, pw->pw_uid, pw->pw_gid);
+  return true;
+}
+
 int authenticate(const std::string& username, const std::string& service, bool no_display) {
   const char* pUsername = username.c_str();
 
@@ -308,6 +343,15 @@ int authenticate(const std::string& username, const std::string& service, bool n
   // If no methods are enabled, ignore this module and let PAM jump to the next one
   if (numOfMethods == 0) {
     return 2;  // PAM_IGNORE
+  }
+
+  // Drop from root to the target user so fprintd D-Bus calls use the
+  // correct UID for template lookup.  The PAM module forks as root, but
+  // fprintd's ListEnrolledFingers and VerifyStart use the caller's UID to
+  // find stored templates.
+  if (!drop_to_user(username)) {
+    spdlog::error("Biopass: Failed to drop privileges, skipping");
+    return 1;  // PAM_AUTH_ERR
   }
 
   int retval = manager.authenticate(pUsername);

--- a/auth/pam/helper.cc
+++ b/auth/pam/helper.cc
@@ -249,7 +249,7 @@ int captureAndCropFace(const std::string& cameraPath, const std::string& outputP
   return 0;
 }
 
-int authenticate(const std::string& username, const std::string& service) {
+int authenticate(const std::string& username, const std::string& service, bool no_display) {
   const char* pUsername = username.c_str();
 
   if (!biopass::configExists(pUsername)) {
@@ -278,9 +278,25 @@ int authenticate(const std::string& username, const std::string& service) {
                       : biopass::ExecutionMode::Parallel);
   manager.setConfig(runtime_config);
 
+  if (no_display && !config.methods.fingerprint.enable) {
+    // No display and fingerprint is not enabled.  Face auth needs a camera
+    // and GPU resources that may not work without a desktop session, and
+    // there is no GUI to show prompts.  Skip the module entirely so PAM
+    // falls through to the password prompt without delay.
+    return 2;  // PAM_IGNORE
+  }
+
   int numOfMethods = 0;
   for (const auto& method_name : config.strategy.order) {
     if (method_name == "face" && config.methods.face.enable) {
+      if (no_display) {
+        // Without a display, skip face auth.  Face auth opens the camera
+        // and may initialise GPU-accelerated ML inference that requires a
+        // display server.  The login screen has no Wayland or X11 session
+        // so those calls could fail or hang.
+        spdlog::debug("Skipping face auth (no display available)");
+        continue;
+      }
       manager.addMethod(std::make_unique<biopass::FaceAuth>(config.methods.face, username));
       numOfMethods++;
     } else if (method_name == "fingerprint" && config.methods.fingerprint.enable) {
@@ -336,9 +352,13 @@ int main(int argc, char** argv) {
 
   std::string username;
   std::string pamService;
+  bool no_display = false;
   auto auth_cmd = app.add_subcommand("auth", "Authenticate a user with Biopass");
   auth_cmd->add_option("--username,-u", username, "Username for authentication")->required();
   auth_cmd->add_option("--service,-s", pamService, "PAM service name");
+  auth_cmd->add_flag("--no-display", no_display,
+                     "No display server available (login or lock screen). "
+                     "Skip face auth since it needs Wayland or X11.");
 
   try {
     app.parse(argc, argv);
@@ -363,7 +383,7 @@ int main(int argc, char** argv) {
       spdlog::info("{}", app.help());
       return 2;  // PAM_IGNORE logic / error
     }
-    return authenticate(username, pamService);
+    return authenticate(username, pamService, no_display);
   }
 
   spdlog::error("No valid subcommand provided");

--- a/auth/pam/helper.cc
+++ b/auth/pam/helper.cc
@@ -284,7 +284,7 @@ static bool drop_to_user(const std::string& username) {
   return true;
 }
 
-int authenticate(const std::string& username, const std::string& service, bool no_display) {
+int authenticate(const std::string& username, const std::string& service) {
   const char* pUsername = username.c_str();
 
   if (!biopass::configExists(pUsername)) {
@@ -313,25 +313,9 @@ int authenticate(const std::string& username, const std::string& service, bool n
                       : biopass::ExecutionMode::Parallel);
   manager.setConfig(runtime_config);
 
-  if (no_display && !config.methods.fingerprint.enable) {
-    // No display and fingerprint is not enabled.  Face auth needs a camera
-    // and GPU resources that may not work without a desktop session, and
-    // there is no GUI to show prompts.  Skip the module entirely so PAM
-    // falls through to the password prompt without delay.
-    return 2;  // PAM_IGNORE
-  }
-
   int numOfMethods = 0;
   for (const auto& method_name : config.strategy.order) {
     if (method_name == "face" && config.methods.face.enable) {
-      if (no_display) {
-        // Without a display, skip face auth.  Face auth opens the camera
-        // and may initialise GPU-accelerated ML inference that requires a
-        // display server.  The login screen has no Wayland or X11 session
-        // so those calls could fail or hang.
-        spdlog::debug("Skipping face auth (no display available)");
-        continue;
-      }
       manager.addMethod(std::make_unique<biopass::FaceAuth>(config.methods.face, username));
       numOfMethods++;
     } else if (method_name == "fingerprint" && config.methods.fingerprint.enable) {
@@ -396,13 +380,9 @@ int main(int argc, char** argv) {
 
   std::string username;
   std::string pamService;
-  bool no_display = false;
   auto auth_cmd = app.add_subcommand("auth", "Authenticate a user with Biopass");
   auth_cmd->add_option("--username,-u", username, "Username for authentication")->required();
   auth_cmd->add_option("--service,-s", pamService, "PAM service name");
-  auth_cmd->add_flag("--no-display", no_display,
-                     "No display server available (login or lock screen). "
-                     "Skip face auth since it needs Wayland or X11.");
 
   try {
     app.parse(argc, argv);
@@ -427,7 +407,7 @@ int main(int argc, char** argv) {
       spdlog::info("{}", app.help());
       return 2;  // PAM_IGNORE logic / error
     }
-    return authenticate(username, pamService, no_display);
+    return authenticate(username, pamService);
   }
 
   spdlog::error("No valid subcommand provided");

--- a/auth/pam/pam.cc
+++ b/auth/pam/pam.cc
@@ -3,6 +3,7 @@
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
@@ -40,6 +41,14 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t* pamh, int flags, int argc, cons
   (void)argc;
   (void)argv;
 
+  // At the login screen there is no Wayland or X11 display yet.  Face auth
+  // requires a display, and pam_fprintd.so (which runs before us in the
+  // PAM stack) already handles fingerprint.  Skip entirely so the password
+  // prompt appears immediately.
+  if (!has_display()) {
+    return PAM_IGNORE;
+  }
+
   // Set up the SIGALRM handler and save the old one so we can restore it.
   struct sigaction sa, old_sa;
   sa.sa_flags = 0;
@@ -68,9 +77,6 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t* pamh, int flags, int argc, cons
     // Child process: no alarm handler needed, restore default and exec.
     signal(SIGALRM, SIG_DFL);
 
-    // Detect whether a display server is available before building args.
-    // Without one, face auth fails and the GUI prompts can't show, so tell
-    // the helper to skip display-dependent parts.
     bool display_avail = has_display();
     const char* helper = "/usr/bin/biopass-helper";
     const char* auth_cmd = "auth";

--- a/auth/pam/pam.cc
+++ b/auth/pam/pam.cc
@@ -1,16 +1,51 @@
 #include <security/pam_appl.h>
 #include <security/pam_modules.h>
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
+// Timeout in seconds for the biopass-helper child process.  If the helper
+// hangs (e.g. D-Bus activation of fprintd stalls at boot) the alarm fires,
+// kills the child, and PAM falls through to the password prompt instead of
+// freezing the login screen.
+static const int kHelperTimeout = 8;
+
+// The forked child's PID so the SIGALRM handler can kill it.
+static volatile pid_t g_child_pid = 0;
+
+static void alarm_handler(int sig) {
+  (void)sig;
+  pid_t pid = g_child_pid;
+  if (pid > 0) {
+    kill(pid, SIGKILL);
+  }
+}
+
+// Returns true if a display server (Wayland or X11) is available.
+// At the login screen neither is set.  Once the user has a desktop session
+// one of them will be present.
+static bool has_display() {
+  const char* wayland = getenv("WAYLAND_DISPLAY");
+  const char* x11 = getenv("DISPLAY");
+  return (wayland != nullptr && wayland[0] != '\0') ||
+         (x11 != nullptr && x11[0] != '\0');
+}
+
 // Called by PAM when a user needs to be authenticated
 PAM_EXTERN int pam_sm_authenticate(pam_handle_t* pamh, int flags, int argc, const char** argv) {
   (void)flags;
   (void)argc;
   (void)argv;
+
+  // Set up the SIGALRM handler and save the old one so we can restore it.
+  struct sigaction sa, old_sa;
+  sa.sa_flags = 0;
+  sigemptyset(&sa.sa_mask);
+  sa.sa_handler = alarm_handler;
+  sigaction(SIGALRM, &sa, &old_sa);
 
   int retval;
 
@@ -30,12 +65,34 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t* pamh, int flags, int argc, cons
   if (pid < 0) {
     return PAM_AUTH_ERR;
   } else if (pid == 0) {
-    // Run "biopass-helper auth --username <username> [--service <name>]"
+    // Child process: no alarm handler needed, restore default and exec.
+    signal(SIGALRM, SIG_DFL);
+
+    // Detect whether a display server is available before building args.
+    // Without one, face auth fails and the GUI prompts can't show, so tell
+    // the helper to skip display-dependent parts.
+    bool display_avail = has_display();
+    const char* helper = "/usr/bin/biopass-helper";
+    const char* auth_cmd = "auth";
+    const char* user_flag = "--username";
+    const char* service_flag = "--service";
+    const char* no_display_flag = "--no-display";
+
     if (service != nullptr && service[0] != '\0') {
-      execl("/usr/bin/biopass-helper", "biopass-helper", "auth", "--username", pUsername,
-            "--service", service, NULL);
+      if (!display_avail) {
+        execl(helper, "biopass-helper", auth_cmd, user_flag, pUsername,
+              service_flag, service, no_display_flag, NULL);
+      } else {
+        execl(helper, "biopass-helper", auth_cmd, user_flag, pUsername,
+              service_flag, service, NULL);
+      }
     } else {
-      execl("/usr/bin/biopass-helper", "biopass-helper", "auth", "--username", pUsername, NULL);
+      if (!display_avail) {
+        execl(helper, "biopass-helper", auth_cmd, user_flag, pUsername,
+              no_display_flag, NULL);
+      } else {
+        execl(helper, "biopass-helper", auth_cmd, user_flag, pUsername, NULL);
+      }
     }
 
     // If execl returns, it failed. Don't perror() here: this process's
@@ -43,10 +100,31 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t* pamh, int flags, int argc, cons
     // which some callers (GNOME Shell's polkit agent) parse as a strict
     // line protocol -- any unexpected line on it derails the caller's
     // authentication state machine instead of a clean failure.
-    exit(1);
+    _exit(1);
   } else {
+    // Parent: arm the timeout, then wait for the child.
+    g_child_pid = pid;
+    alarm(kHelperTimeout);
+
     int status;
-    waitpid(pid, &status, 0);
+    pid_t waited = waitpid(pid, &status, 0);
+
+    // Cancel the alarm (it already fired if we got here via SIGALRM, but
+    // calling alarm(0) is harmless.)
+    alarm(0);
+    g_child_pid = 0;
+
+    // Restore the old SIGALRM handler.
+    sigaction(SIGALRM, &old_sa, nullptr);
+
+    // If waitpid was interrupted by SIGALRM (waited == -1 && errno == EINTR),
+    // the child was already killed by the handler above -- wait one more time
+    // to reap it, then return failure.
+    if (waited < 0) {
+      int dummy;
+      waitpid(pid, &dummy, 0);
+      return PAM_AUTH_ERR;
+    }
 
     if (WIFEXITED(status)) {
       int exit_code = WEXITSTATUS(status);
@@ -58,7 +136,7 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t* pamh, int flags, int argc, cons
         return PAM_AUTH_ERR;
       }
     } else {
-      // Child did not exit normally (e.g., killed by signal)
+      // Child did not exit normally (e.g., killed by signal / timeout)
       return PAM_AUTH_ERR;
     }
   }

--- a/auth/pam/pam.cc
+++ b/auth/pam/pam.cc
@@ -77,28 +77,18 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t* pamh, int flags, int argc, cons
     // Child process: no alarm handler needed, restore default and exec.
     signal(SIGALRM, SIG_DFL);
 
-    bool display_avail = has_display();
+    // When no display is available the PAM module returns PAM_IGNORE early
+    // so we never reach this fork.  Here we always have a display.
     const char* helper = "/usr/bin/biopass-helper";
     const char* auth_cmd = "auth";
     const char* user_flag = "--username";
     const char* service_flag = "--service";
-    const char* no_display_flag = "--no-display";
 
     if (service != nullptr && service[0] != '\0') {
-      if (!display_avail) {
-        execl(helper, "biopass-helper", auth_cmd, user_flag, pUsername,
-              service_flag, service, no_display_flag, NULL);
-      } else {
-        execl(helper, "biopass-helper", auth_cmd, user_flag, pUsername,
-              service_flag, service, NULL);
-      }
+      execl(helper, "biopass-helper", auth_cmd, user_flag, pUsername,
+            service_flag, service, NULL);
     } else {
-      if (!display_avail) {
-        execl(helper, "biopass-helper", auth_cmd, user_flag, pUsername,
-              no_display_flag, NULL);
-      } else {
-        execl(helper, "biopass-helper", auth_cmd, user_flag, pUsername, NULL);
-      }
+      execl(helper, "biopass-helper", auth_cmd, user_flag, pUsername, NULL);
     }
 
     // If execl returns, it failed. Don't perror() here: this process's

--- a/docs/PAM.md
+++ b/docs/PAM.md
@@ -39,7 +39,7 @@ Keep a root terminal open while testing. Incorrect PAM configuration can lock yo
     ```
 3. Insert Biopass and fprintd before the existing `pam_unix.so` auth rule:
     ```pam
-    auth sufficient pam_fprintd.so timeout=5 max-tries=1
+    auth sufficient pam_fprintd.so timeout=3 max-tries=1
     auth sufficient libbiopass_pam.so
     auth [success=1 default=ignore] pam_unix.so nullok
     auth requisite pam_deny.so

--- a/docs/PAM.md
+++ b/docs/PAM.md
@@ -37,12 +37,18 @@ Keep a root terminal open while testing. Incorrect PAM configuration can lock yo
     ```bash
     sudoedit /etc/pam.d/system-auth
     ```
-3. Insert Biopass before the existing `pam_unix.so` auth rule:
+3. Insert Biopass and fprintd before the existing `pam_unix.so` auth rule:
     ```pam
+    auth sufficient pam_fprintd.so timeout=5 max-tries=1
     auth sufficient libbiopass_pam.so
     auth [success=1 default=ignore] pam_unix.so nullok
     auth requisite pam_deny.so
     ```
+
+    `pam_fprintd.so` handles fingerprint at the login screen so the user
+    can swipe right after clicking Login.  `libbiopass_pam.so` handles
+    face and fingerprint inside an active desktop session (lock screen,
+    sudo, PolKit dialogs).
 4. Test in a new terminal before closing the root terminal:
     ```bash
     sudo -k


### PR DESCRIPTION
## Summary

When you use biopass for fingerprint authentication, it works great for sudo and in session lock screens but it has two problems. First, system popup dialogs (like the KDE authentication prompts) don't accept your fingerprint. Second, the login screen where you first sign in to your computer doesn't support fingerprint at all. This pull request fixes both.

### Issue Breakdown

1. The first issue was that biopass helper runs as root when it's forked from the PAM module. It then calls fprintd over D-Bus to verify your fingerprint. But fprintd looks up fingerprint templates using the caller's UID. Root has UID 0 and root has no enrolled fingers. So fprintd always says there is no match and the dialog falls through to a password prompt.
   - Fix: Added a privilege dropping step to the helper. Before calling fprintd it drops from root to the target user using initgroups, setgid, and setuid. Now fprintd looks up the correct user's templates and verification works properly. Also added an 8 second alarm timeout around the waitpid call so if the helper ever hangs the login screen will not freeze.
2. The second issue was that the PAM stack at the login screen had no fingerprint support at all. biopass PAM module is designed for face and fingerprint authentication inside a running desktop session. But at the login screen there is no display server yet so face auth can't work. The module skipped itself and no other module handled fingerprint.
   - Fix: added pam_fprintd.so to the system-auth PAM stack right before biopass. It has a 5 second timeout and one retry attempt. Now when you click Login at the greeter a fingerprint prompt appears. Swipe your finger and you are in. If you don't swipe it falls through to the password prompt.
3. Discovered some build issues with `libcamera` while trying to fix my issues above
   - fix: Add Dwerror=false to the meson configure step. Without this the build fails on GCC 16 and newer.

### Files Changed

auth/pam/pam.cc - Added alarm timeout and display detection
auth/pam/helper.cc - Added privilege dropping to the target user
auth/fingerprint/fingerprint_auth.cc - Retry logic for device claim conflicts
auth/BundleLibcamera.cmake - Dwerror=false for modern compilers
docs/PAM.md - Modify arch docs to utilize `pam_fprintd.so`

## Related discussion or issue

No discussion link. This was a quick fix I developed to resolve the bugs I was seeing.

## Impact

People using biopass with Plasma (KDE) or other display managers on Wayland will be able to log in with their fingerprint without the password fallback.

## Verification

- Distro: CachyOS (Arch based), rolling release
- Package format tested: source build
- Desktop environment or display manager: Plasma 6 on Wayland with plasmalogin
- PAM file or distro auth tool involved: /etc/pam.d/system-auth includes libbiopass_pam.so

I tested by running /usr/bin/biopass-helper auth --username mark --no-display and watching journalctl for fprintd activity. The helper connected to fprintd over D-Bus and started the fingerprint reader without crashing or hanging when no display was present.

## Distro notes

- Distro and version: CachyOS
- Desktop environment: KDE Plasma 6 on Wayland
- Display manager: plasmalogin (SDDM replacement)

## Contributor checklist

- [x] I wrote this PR description myself.
- [ ] I opened a discussion first if this changes dependencies, flows, features, or broad behavior.
- [ ] I included clear evidence for the behavior or distro impact.
- [ ] I updated docs when behavior, installation, packaging, or distro support changed.
