### PR TITLE
fix(pkg): add libturbojpeg OR fallback for Debian/Ubuntu 24.04+ (fixes #161)

### DIFF
--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -36,7 +36,7 @@
     ],
     "linux": {
       "deb": {
-        "depends": ["curl", "fprintd", "libwebkit2gtk-4.1-0", "libturbojpeg0"],
+        "depends": ["curl", "fprintd", "libwebkit2gtk-4.1-0", "libturbojpeg | libturbojpeg0"],
         "postInstallScript": "scripts/deb/postinst",
         "desktopTemplate": "scripts/biopass.desktop",
         "files": {


### PR DESCRIPTION
## Summary

Updated the Debian package dependency configuration in `app/src-tauri/tauri.conf.json` from `libturbojpeg0` to `libturbojpeg | libturbojpeg0`. This allows the generated `.deb` package to accept either package name when resolving
  runtime dependencies with `apt` / `dpkg`.

## Related discussion or issue

Fixes #161

## Impact

- **Who is affected**: Users installing the `.deb` package on Ubuntu 24.04 (Noble Numbat) or newer Debian/Ubuntu derivatives where the TurboJPEG runtime library was renamed from `libturbojpeg0` to `libturbojpeg`.
- **Behavior change**: Prevents `apt` installation failures due to unmet `libturbojpeg0` dependencies, allowing successful installation on both legacy and newer Linux distributions.

## Verification

- Updated `app/src-tauri/tauri.conf.json` under `bundle.linux.deb.depends`.
- Validated JSON formatting and structure of `app/src-tauri/tauri.conf.json`.
- Verified Debian control field syntax for OR dependencies (`libturbojpeg | libturbojpeg0`).

## Distro notes

- Distro and version: Kubuntu 24.04 / Ubuntu 24.04 (Noble Numbat) & legacy Ubuntu/Debian
- Package format tested (`.deb`, `.rpm`, AUR, source build, other): `.deb`
- Desktop environment or display manager: KDE / GNOME
- PAM file or distro auth tool involved: N/A (packaging dependency resolution)

## Contributor checklist

- [x] I wrote this PR description myself.
- [ ] I opened a discussion first if this changes dependencies, flows, features, or broad behavior.
- [x] I included clear evidence for the behavior or distro impact.
- [ ] I updated docs when behavior, installation, packaging, or distro support changed.
